### PR TITLE
feature/omega from ext

### DIFF
--- a/parsers/nmparser/parse_parameter_structure.go
+++ b/parsers/nmparser/parse_parameter_structure.go
@@ -13,6 +13,11 @@ type ParameterStructures struct {
 }
 
 func parseParameterStructure(lines []string) []int {
+
+	if len(lines) == 0 {
+		return nil
+	}
+
 	if strings.Contains(lines[0], "SIMPLE") {
 		omegaLength, _ := strconv.Atoi(strings.TrimSpace(strings.SplitAfter(lines[0], ":")[1]))
 		return createDiagonalBlock(omegaLength)

--- a/parsers/nmparser/summary.go
+++ b/parsers/nmparser/summary.go
@@ -51,9 +51,7 @@ func (results ModelOutput) Summary() bool {
 
 	diagIndices := GetDiagonalIndices(results.ParameterStructures.Omega)
 	for n, omegaIndex := range diagIndices {
-		//shrinkageValue := "0"
 		var shrinkageValue string
-		//val := 0.0
 		var val float64
 		if len(results.ShrinkageDetails) > 0 {
 			// get the data for the last method
@@ -70,7 +68,7 @@ func (results ModelOutput) Summary() bool {
 		}
 
 		etaName := fmt.Sprintf("ETA%v", n+1)
-		omegaIndices := fmt.Sprintf("(%s,%s)", strconv.Itoa(n), strconv.Itoa(n))
+		omegaIndices := fmt.Sprintf("(%s,%s)", strconv.Itoa(n+1), strconv.Itoa(n+1))
 		omegaTable.Append([]string{string("O" + omegaIndices), etaName, fmt.Sprintf("%f", val), shrinkageValue})
 	}
 


### PR DESCRIPTION
changes to support #52 
The reason we don't **_always_** use the ext file to get Omega info is because the lst file has more information than the ext file. The ext file only provides the length (dimension) of the Omega block.