### PR TITLE
Updating with a randomized timer for local mode execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
-nonmemutils.coverage
-.idea/
-.DS_Store
+*

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -52,7 +52,7 @@ func (l LocalModel) Prepare(channels *turnstile.ChannelMap) {
 		randomizedTimer := randomFloat(1, l.Nonmem.Configuration.Delay)
 
 		if l.Nonmem.Configuration.Debug {
-			log.Printf("Random delay of %f seconds introduced for model %s", randomizedTimer, l.Nonmem.FileName)
+			log.Infof("Random delay of %f seconds introduced for model %s", randomizedTimer, l.Nonmem.FileName)
 		}
 
 		time.Sleep(time.Duration(randomizedTimer) * time.Second)

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -45,6 +45,18 @@ func (l LocalModel) CancellationChannel() chan bool {
 //Prepare is basically the old EstimateModel function. Responsible for creating directories and preparation.
 func (l LocalModel) Prepare(channels *turnstile.ChannelMap) {
 
+	//Jitter / Delay
+	if l.Nonmem.Configuration.Delay > 0 {
+		//Add a random Timer
+		randomizedTimer := randomInteger(1, l.Nonmem.Configuration.Delay)
+
+		if l.Nonmem.Configuration.Debug {
+			log.Printf("Random delay of %d seconds introduced", randomizedTimer)
+		}
+
+		time.Sleep(time.Duration(randomizedTimer) * time.Second)
+	}
+
 	//Mark the model as started some work
 	channels.Working <- 1
 

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -48,10 +48,10 @@ func (l LocalModel) Prepare(channels *turnstile.ChannelMap) {
 	//Jitter / Delay
 	if l.Nonmem.Configuration.Delay > 0 {
 		//Add a random Timer
-		randomizedTimer := randomInteger(1, l.Nonmem.Configuration.Delay)
+		randomizedTimer := randomFloat(1, l.Nonmem.Configuration.Delay)
 
 		if l.Nonmem.Configuration.Debug {
-			log.Printf("Random delay of %d seconds introduced for model %s", randomizedTimer, l.Nonmem.FileName)
+			log.Printf("Random delay of %f seconds introduced for model %s", randomizedTimer, l.Nonmem.FileName)
 		}
 
 		time.Sleep(time.Duration(randomizedTimer) * time.Second)

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -51,7 +51,7 @@ func (l LocalModel) Prepare(channels *turnstile.ChannelMap) {
 		randomizedTimer := randomInteger(1, l.Nonmem.Configuration.Delay)
 
 		if l.Nonmem.Configuration.Debug {
-			log.Printf("Random delay of %d seconds introduced", randomizedTimer)
+			log.Printf("Random delay of %d seconds introduced for model %s", randomizedTimer, l.Nonmem.FileName)
 		}
 
 		time.Sleep(time.Duration(randomizedTimer) * time.Second)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,6 +115,6 @@ func flagChanged(flags *flag.FlagSet, key string) bool {
 
 //Assumes random has been set previously and seeded to avoid reproducible data sets
 //Here random is set during root.go setup
-func randomInteger(min int, max int) int {
-	return rand.Intn(max-min) + min
+func randomFloat(min int, max int) float64 {
+	return float64(float64(min) + rand.Float64()*(float64(max)-float64(min)))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,6 +85,7 @@ func init() {
 	// will be global for your application.
 
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/babylon.yaml)")
+	viper.BindPFlag("config", RootCmd.PersistentFlags().Lookup("config")) //Bind config to viper to make sure it'll parse
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "debug mode")
 	viper.BindPFlag("debug", RootCmd.PersistentFlags().Lookup("debug")) //Bind Debug to viper

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,11 +16,8 @@ package cmd
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"math/rand"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/metrumresearchgroup/babylon/configlib"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,7 +16,9 @@ package cmd
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/metrumresearchgroup/babylon/configlib"
 	"github.com/spf13/cobra"
@@ -65,6 +67,10 @@ func Execute(build string) {
 }
 
 func init() {
+
+	//Set random for application
+	rand.Seed(time.Now().UnixNano())
+
 	cobra.OnInitialize(initConfig)
 
 	//Removed "." To avoid IDEs not displaying or typical ignore patterns dropping it.
@@ -78,10 +84,11 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/babylon.yaml)")
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "debug mode")
+	viper.BindPFlag("debug", RootCmd.PersistentFlags().Lookup("debug")) //Bind Debug to viper
 	RootCmd.PersistentFlags().IntVar(&threads, "threads", 4, "number of threads to execute with")
-	viper.BindPFlag("threads", RootCmd.PersistentFlags().Lookup("threads"))                                               //Update to make sure viper binds to the flag
-	RootCmd.PersistentFlags().BoolVar(&Json, "json", false, "json tree of output, if possible")                           //TODO: Implement
-	RootCmd.PersistentFlags().BoolVarP(&preview, "preview", "p", false, "preview action, but don't actually run command") //TODO: Implement
+	viper.BindPFlag("threads", RootCmd.PersistentFlags().Lookup("threads")) //Update to make sure viper binds to the flag
+	RootCmd.PersistentFlags().BoolVar(&Json, "json", false, "json tree of output, if possible")
+	RootCmd.PersistentFlags().BoolVarP(&preview, "preview", "p", false, "preview action, but don't actually run command")
 	//Used for Summary
 	RootCmd.PersistentFlags().BoolVarP(&noExt, "no-ext-file", "", false, "do not use ext file")
 	RootCmd.PersistentFlags().BoolVarP(&noGrd, "no-grd-file", "", false, "do not use grd file")
@@ -104,4 +111,10 @@ func flagChanged(flags *flag.FlagSet, key string) bool {
 		return false
 	}
 	return flag.Changed
+}
+
+//Assumes random has been set previously and seeded to avoid reproducible data sets
+//Here random is set during root.go setup
+func randomInteger(min int, max int) int {
+	return rand.Intn(max-min) + min
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -66,6 +66,10 @@ func init() {
 	runCmd.PersistentFlags().Bool(saveconfig, true, "Whether or not to save the existing configuration to a file with the model")
 	viper.BindPFlag(saveconfig, runCmd.PersistentFlags().Lookup(saveconfig))
 
+	const delayIdentifier string = "delay"
+	runCmd.PersistentFlags().Int(delayIdentifier, 0, "Selects a random number of seconds between 1 and this value to stagger / jitter job execution. Assists in dealing with large volumes of work dealing with the same data set. May avoid NMTRAN issues about not being able read / close files")
+	viper.BindPFlag(delayIdentifier, runCmd.PersistentFlags().Lookup(delayIdentifier))
+
 	nonmemCmd.AddCommand(runCmd)
 
 }

--- a/configlib/config.go
+++ b/configlib/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	Debug         bool                    `yaml:"debug" json:"debug,omitempty"`
 	Nonmem        map[string]NonMemDetail `mapstructure:"nonmem" json:"nonmem,omitempty"`
 	Parallel      ParallelConfig          `mapstructure:"parallel" json:"parallel"`
+	Delay         int                     `yaml:"delay" json:"delay,omitempty"`
 }
 
 type NonMemDetail struct {


### PR DESCRIPTION
* Random is initialized off of the timer during root init
* `--delay` flag introduced with default value of 0
* If delay value in configuration is greater than default:
    * A random integer between 1 and the provided delay is selected
        * This avoids synchronization. If you just specify a delay of 4 and 4 seconds is selected, all of the jobs will begin execution after waiting 4 seconds. This would still yield the IO problems. Just on a delay
        * If debug is set, it will display the random seconds elected for delay
