### PR TITLE
Moving config up front

### DIFF
--- a/cmd/sge.go
+++ b/cmd/sge.go
@@ -60,13 +60,6 @@ func (l SGEModel) Prepare(channels *turnstile.ChannelMap) {
 		return
 	}
 
-	//err = configlib.WriteViperConfig(l.Nonmem.OutputDir, true, l.Nonmem.Configuration)
-	//
-	//if err != nil {
-	//	log.Errorf("Error Details are %s", err)
-	//	RecordConcurrentError(l.Nonmem.FileName, "Failure occurred saving the babylon yaml into the child dir", err, channels, l.Cancel)
-	//}
-
 	//Create Execution Script
 	scriptContents, err := generateBabylonScript(nonMemExecutionTemplate, *l.Nonmem)
 

--- a/cmd/sge.go
+++ b/cmd/sge.go
@@ -45,37 +45,27 @@ func (l SGEModel) Prepare(channels *turnstile.ChannelMap) {
 	//Mark the model as started some work
 	channels.Working <- 1
 
-	//Load the original config if specified, otherwise pull locally relative.
-	var config string
-	if len(viper.GetString("config")) > 0 {
-		config = viper.GetString("config")
-	} else {
-		config = filepath.Join(l.Nonmem.OriginalPath, "babylon.yaml")
-	}
-
-	err := configlib.LoadViperFromFile(config)
-
-	//If we can't load the configuration, let's basically stop
-	if err != nil {
-		RecordConcurrentError(l.Nonmem.FileName, "An error occurred trying to"+
-			" load the configuration file", err, channels, l.Cancel)
-		return
-	}
-
-	l.Nonmem.Configuration = configlib.UnmarshalViper()
-
 	fs := afero.NewOsFs()
 
 	log.Debugf("%s Overwrite is currrently set to %t", l.Nonmem.LogIdentifier(), l.Nonmem.Configuration.Overwrite)
 	log.Debugf("%s Beginning evaluation of whether or not %s exists", l.Nonmem.LogIdentifier(), l.Nonmem.OutputDir)
 
-	err = createChildDirectories(l.Nonmem, l.Cancel, channels, true)
+	err := createChildDirectories(l.Nonmem, l.Cancel, channels, true)
+
+	//Save the config into the output directory
 
 	if err != nil {
 		//Handles the cancel operation
 		RecordConcurrentError(l.Nonmem.FileName, err.Error(), err, channels, l.Cancel)
 		return
 	}
+
+	//err = configlib.WriteViperConfig(l.Nonmem.OutputDir, true, l.Nonmem.Configuration)
+	//
+	//if err != nil {
+	//	log.Errorf("Error Details are %s", err)
+	//	RecordConcurrentError(l.Nonmem.FileName, "Failure occurred saving the babylon yaml into the child dir", err, channels, l.Cancel)
+	//}
 
 	//Create Execution Script
 	scriptContents, err := generateBabylonScript(nonMemExecutionTemplate, *l.Nonmem)
@@ -152,51 +142,30 @@ func init() {
 
 func sge(cmd *cobra.Command, args []string) {
 
+	config := configlib.LocateAndReadConfigFile()
+	log.Info("Beginning Local Path")
+
 	lo := sgeOperation{}
 
 	//If we're in debug mode, let's set the logger to debug
-	if viper.GetBool("debug") {
+	if config.Debug {
 		log.SetLevel(log.DebugLevel)
 	}
 
 	log.Debug("Searching for models based on arguments")
+	lomodels, err := sgeModelsFromArguments(args, &config)
+	if err != nil {
+		log.Fatalf("An error occurred during model processing: %s", err)
+	}
 
-	lo.Models = sgeModelsFromArguments(args)
+	lo.Models = lomodels
 
 	if len(lo.Models) == 0 {
 		log.Fatal("No models were located or loaded. Please verify the arguments provided and try again")
 	}
 
-	//TODO: Change this logic
-	log.Debug("Beginning config save / load operations for SGE Path")
-	//Save the config file to the directory to facilitate further execution
-	configlib.SaveConfig(lo.Models[0].Nonmem.OriginalPath)
-	//Read it in to make sure we're not trying to save it again later
-	configlib.LocateAndReadConfigFile(lo.Models[0].Nonmem.OriginalPath)
-
 	//Models Added
 	log.Infof("A total of %d models have been located for work", len(lo.Models))
-
-	//Models in Error
-	//Locate 'em
-	var errors []*NonMemModel
-	for _, v := range lo.Models {
-		if v.Nonmem.Error != nil {
-			errors = append(errors, v.Nonmem)
-		}
-	}
-
-	if len(errors) > 0 {
-		log.Errorf("It appears that %d models generated an error during the initial setup phase", len(errors))
-		for _, v := range errors {
-			log.Errorf("Model named %s has errored. Details: %s", v.Model, v.Error.Error())
-		}
-
-		log.Fatal("Errors occurred during the setup of models. Please rectify these issues and try again")
-	}
-
-	//Models in OK state
-	log.Infof("%d models successfully completed initial setup phase.", len(lo.Models)-len(errors))
 
 	//Create signature safe slice for manager
 	var scalables []turnstile.Scalable
@@ -310,9 +279,13 @@ func executeSGEJob(model *NonMemModel) turnstile.ConcurrentError {
 	return turnstile.ConcurrentError{}
 }
 
-func sgeModelsFromArguments(args []string) []SGEModel {
+func sgeModelsFromArguments(args []string, config *configlib.Config) ([]SGEModel, error) {
 	var output []SGEModel
-	nonmemmodels := nonmemModelsFromArguments(args)
+	nonmemmodels, err := nonmemModelsFromArguments(args, config)
+
+	if err != nil {
+		return output, err
+	}
 
 	for _, v := range nonmemmodels {
 		n := v
@@ -322,7 +295,7 @@ func sgeModelsFromArguments(args []string) []SGEModel {
 		})
 	}
 
-	return output
+	return output, nil
 }
 
 //Generate the command line script to execute babylon on the grid.

--- a/configlib/config.go
+++ b/configlib/config.go
@@ -164,6 +164,7 @@ func LocateAndReadConfigFile() Config {
 	var config Config
 
 	if len(viper.GetString("config")) == 0 {
+		log.Debug("No config has been specified. Attempting to load default")
 		currentDir, err := os.Getwd()
 
 		if err != nil {
@@ -181,6 +182,7 @@ func LocateAndReadConfigFile() Config {
 
 	//Config provided
 	if len(viper.GetString("config")) > 0 {
+		log.Debugf("A config file has been specified at %s", viper.GetString("config"))
 		var err error
 		config, err = ReadSpecifiedFileIntoConfigStruct(viper.GetString("config"))
 

--- a/configlib/config.go
+++ b/configlib/config.go
@@ -188,7 +188,7 @@ func LocateAndReadConfigFile() Config {
 			log.Fatalf("Configuration file provided at %s could not be loaded. Error is: %s ", viper.GetString("config"), err)
 		}
 
-		log.Infof("Successfully loaded default configuration from %s", viper.GetString("config"))
+		log.Infof("Successfully loaded specified configuration from %s", viper.GetString("config"))
 	}
 
 	return config


### PR DESCRIPTION
Changing process to look for config in local directory or a provided config.  Not waiting to locate the models allows us to set the config item up front and pass a pointer to it to all nonmem models (or any other implementation) underneath it