### PR TITLE
Json logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .idea
 dist
+babylon.log

--- a/cmd/bbi/.gitignore
+++ b/cmd/bbi/.gitignore
@@ -5,4 +5,5 @@ Execute_with_Delay
 Local_Execution
 SGE_Execution
 Specified_Configuration
+JSON_Logging
 dist

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -301,10 +301,7 @@ func local(cmd *cobra.Command, args []string) {
 	config := configlib.LocateAndReadConfigFile()
 	log.Info("Beginning Local Path")
 
-	//Set Logrus level if we're debug
-	if config.Debug {
-		log.SetLevel(log.DebugLevel)
-	}
+	logSetup(config)
 
 	lo := localOperation{}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
+	"io"
 	"math/rand"
 	"os"
 	"path"
@@ -169,6 +170,7 @@ func logSetup(config configlib.Config) {
 			outfile = of
 		}
 
-		log.SetOutput(outfile)
+		tee := io.MultiWriter(outfile, os.Stdout)
+		log.SetOutput(tee)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,8 +16,12 @@ package cmd
 
 import (
 	"fmt"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 	"math/rand"
 	"os"
+	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/metrumresearchgroup/babylon/configlib"
@@ -86,6 +90,7 @@ func init() {
 	RootCmd.PersistentFlags().IntVar(&threads, "threads", 4, "number of threads to execute with")
 	viper.BindPFlag("threads", RootCmd.PersistentFlags().Lookup("threads")) //Update to make sure viper binds to the flag
 	RootCmd.PersistentFlags().BoolVar(&Json, "json", false, "json tree of output, if possible")
+	viper.BindPFlag("json", RootCmd.PersistentFlags().Lookup("json")) //Bind to viper
 	RootCmd.PersistentFlags().BoolVarP(&preview, "preview", "p", false, "preview action, but don't actually run command")
 	//Used for Summary
 	RootCmd.PersistentFlags().BoolVarP(&noExt, "no-ext-file", "", false, "do not use ext file")
@@ -115,4 +120,55 @@ func flagChanged(flags *flag.FlagSet, key string) bool {
 //Here random is set during root.go setup
 func randomFloat(min int, max int) float64 {
 	return float64(float64(min) + rand.Float64()*(float64(max)-float64(min)))
+}
+
+func logSetup(config configlib.Config) {
+	//Set Logrus level if we're debug
+	if config.Debug {
+		log.Info("Setting logging to DEBUG")
+		log.SetLevel(log.DebugLevel)
+	}
+
+	if config.JSON {
+		log.Debugf("Setting logrus output formatter to JSON")
+		log.SetFormatter(&log.JSONFormatter{})
+	}
+
+	if len(config.Logfile) > 0 {
+		log.Debugf("A logfile has been specified at %s", config.Logfile)
+		logfile := config.Logfile
+
+		//If the path is relative
+		if !path.IsAbs(config.Logfile) {
+			log.Debugf("The config file specified at %s appears to be relatively referenced", config.Logfile)
+			whereami, err := os.Getwd()
+			if err != nil {
+				log.Fatalf("Unable to get current directory! Details are mysteriously: %s", err)
+			}
+
+			log.Debugf("Updating to use log file of %s", filepath.Join(whereami, config.Logfile))
+			logfile = filepath.Join(whereami, config.Logfile)
+		}
+
+		fs := afero.NewOsFs()
+		var outfile afero.File
+
+		if ok, _ := afero.Exists(fs, logfile); ok {
+			of, err := fs.OpenFile(logfile, os.O_APPEND|os.O_WRONLY, 0755)
+
+			if err != nil {
+				log.Fatalf("Unable to open file at %s. Error is %s", logfile, err)
+			}
+			outfile = of
+		} else {
+			//Doesn't exist. Let's create
+			of, err := fs.Create(logfile)
+			if err != nil {
+				log.Fatalf("Error creating new log file located at %s. Details are: %s", logfile, err)
+			}
+			outfile = of
+		}
+
+		log.SetOutput(outfile)
+	}
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -74,6 +74,10 @@ func init() {
 	runCmd.PersistentFlags().Int(delayIdentifier, 0, "Selects a random number of seconds between 1 and this value to stagger / jitter job execution. Assists in dealing with large volumes of work dealing with the same data set. May avoid NMTRAN issues about not being able read / close files")
 	viper.BindPFlag(delayIdentifier, runCmd.PersistentFlags().Lookup(delayIdentifier))
 
+	const logFileIdentifier string = "logFile"
+	runCmd.PersistentFlags().String(logFileIdentifier, "", "If populated, specifies the file into which to store the output / logging details from Babylon")
+	viper.BindPFlag(logFileIdentifier, runCmd.PersistentFlags().Lookup(logFileIdentifier))
+
 	nonmemCmd.AddCommand(runCmd)
 
 }

--- a/cmd/sge.go
+++ b/cmd/sge.go
@@ -139,10 +139,7 @@ func sge(cmd *cobra.Command, args []string) {
 
 	lo := sgeOperation{}
 
-	//If we're in debug mode, let's set the logger to debug
-	if config.Debug {
-		log.SetLevel(log.DebugLevel)
-	}
+	logSetup(config)
 
 	log.Debug("Searching for models based on arguments")
 	lomodels, err := sgeModelsFromArguments(args, &config)

--- a/configlib/config.go
+++ b/configlib/config.go
@@ -31,6 +31,8 @@ type Config struct {
 	Parallel      ParallelConfig          `mapstructure:"parallel" json:"parallel" yaml:"parallel"`
 	Delay         int                     `yaml:"delay" json:"delay,omitempty" yaml:"delay"`
 	NMQual        bool                    `yaml:"nmqual" json:"nmqual,omitempty"`
+	JSON          bool                    `yaml:"json_logging" json:"json_logging,omitempty"`
+	Logfile       string                  `yaml:"log_file" json:"log_file,omitempty"`
 }
 
 type NonMemDetail struct {


### PR DESCRIPTION
Adds the following:

- If `json` is set as a flag, logging for logrus will use a JsonFormatter
- if `logFile` is set, we will write out to that file as well as stdout via multiwriter
    - If the file is relative, (ie `babylon_output.log`) we will write it specifcally to that location and store the relative reference
    - If the file is absolute, we will write to the absolute reference and store it in the config