### PR TITLE
Notify users of issues with data

### DIFF
--- a/cmd/nonmem.go
+++ b/cmd/nonmem.go
@@ -687,7 +687,7 @@ func NewNonMemModel(modelname string, config *configlib.Config) (NonMemModel, er
 	}
 
 	//Verify the file can be accessed
-	err = dataFileIsSane(datafile, modelname)
+	err = dataFileIsPresent(datafile, modelname)
 
 	if err != nil {
 		return NonMemModel{}, err
@@ -956,7 +956,7 @@ func modelDataFile(modelLines []string) (string, error) {
 			fields := strings.Fields(v)
 			if len(fields) < 2 {
 				return "", fmt.Errorf("the model file contains a $DATA directive, but doesn't appear to specify "+
-					"a target. %s is the line contents", v)
+					"a target. %s is the content of the line", v)
 			}
 
 			return fields[1], nil
@@ -966,7 +966,7 @@ func modelDataFile(modelLines []string) (string, error) {
 	return "", fmt.Errorf("no $DATA line as found in the model file")
 }
 
-func dataFileIsSane(datafile string, modelpath string) error {
+func dataFileIsPresent(datafile string, modelpath string) error {
 
 	var dataFile *os.File
 	var err error


### PR DESCRIPTION
During `newNonMemModel` (Specifically selected because the arguments have been expanded), the model file is read and checked to see:

- Does It Contain a `$DATA` line
- Does that line contain a target (IE a File)
- Is the file accessible

If any of the above are false, it bubbles up an error and the application halts, letting the user know something was wrong with the data requested by the model.