### PR TITLE
Changing how data file is located

### DIFF
--- a/cmd/nonmem.go
+++ b/cmd/nonmem.go
@@ -741,14 +741,9 @@ func NewNonMemModel(modelname string, config *configlib.Config) (NonMemModel, er
 
 	//If the file is a ctl let's strip one ".." off. This is because we are trying to locate the data file from the
 	//perspective of the model file we're targeting, and the file has already been updated for the future state directory
-	if lm.Extension == "ctl" {
+	//Note that we only do this in the scope of creating child directories.
+	if lm.Extension == "ctl" && config.Local.CreateChildDirs {
 		basefilePath = strings.Replace(basefilePath, "../", "", 1)
-	}
-
-	//If we're operating in the perspectus of the output directory, we'll need to append the parent directory
-	//to the base file path to target the same file
-	if !config.Local.CreateChildDirs {
-		basefilePath = filepath.Join("../", basefilePath)
 	}
 
 	absDataFile, err := filepath.Abs(basefilePath)

--- a/cmd/nonmem.go
+++ b/cmd/nonmem.go
@@ -22,6 +22,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"text/template"
@@ -725,18 +726,49 @@ func NewNonMemModel(modelname string, config *configlib.Config) (NonMemModel, er
 	//We'll leverage that to locate the file in the original location regardless of
 	//file type.
 
-	if filepath.IsAbs(datafile) {
-		err = dataFileIsPresent(datafile, modelname)
-	} else {
-		if config.Local.CreateChildDirs {
-			component := filepath.Join(lm.OriginalPath, filepath.Base(datafile))
-			err = dataFileIsPresent(component, modelname)
-		} else {
-			component := filepath.Join(filepath.Dir(lm.OriginalPath), filepath.Base(datafile))
-			err = dataFileIsPresent(component, modelname)
-		}
-
+	whereami, err := os.Getwd()
+	if err != nil {
+		return NonMemModel{}, err
 	}
+
+	err = os.Chdir(lm.OriginalPath)
+
+	if err != nil {
+		return NonMemModel{}, err
+	}
+
+	basefilePath := datafile
+
+	//If the file is a ctl let's strip one ".." off. This is because we are trying to locate the data file from the
+	//perspective of the model file we're targeting, and the file has already been updated for the future state directory
+	if lm.Extension == "ctl" {
+		basefilePath = strings.Replace(basefilePath, "../", "", 1)
+	}
+
+	//If we're operating in the perspectus of the output directory, we'll need to append the parent directory
+	//to the base file path to target the same file
+	if !config.Local.CreateChildDirs {
+		basefilePath = filepath.Join("../", basefilePath)
+	}
+
+	absDataFile, err := filepath.Abs(basefilePath)
+
+	if err != nil {
+		return NonMemModel{}, err
+	}
+
+	//If Mac, strip the /private from the interpreted symlink https://apple.stackexchange.com/questions/1043/why-is-tmp-a-symlink-to-private-tmp
+	if runtime.GOOS == "darwin" {
+		absDataFile = strings.TrimPrefix(absDataFile, "/private")
+	}
+
+	err = dataFileIsPresent(absDataFile, modelname)
+
+	if err != nil {
+		return NonMemModel{}, err
+	}
+
+	err = os.Chdir(whereami)
 
 	if err != nil {
 		return NonMemModel{}, err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,7 +32,7 @@ import (
 )
 
 // VERSION is the current bbi version
-var VERSION string = "2.1.0-alpha.15"
+var VERSION string = "2.1.0-alpha.16"
 
 var (
 	// name of config file

--- a/validation.json
+++ b/validation.json
@@ -40,7 +40,8 @@
       "name" : "Babylon should notify users of issues with the data referenced in the control stream",
       "tags" : [
         "TestHasValidPathForCTL",
-        "TestHasInvalidDataPath"
+        "TestHasInvalidDataPath",
+        "TestHasValidComplexPathCTLAndMod"
       ],
       "risk" : "low",
       "markdown" : [


### PR DESCRIPTION
Previously had too shallow of an approach, purely looking at stripping a single directory layer off the original path during certain scenarios. This worked in our simple test scenarios, but in complex scenarios such as the Metrum boiler plate, it would never work. 

Now 
* We navigate to the original path (where the model is now)
* Read the data line from the model
* If the extension is `ctl` and `createChildDirs` is true (normal execution)
    * we strip a '../' from the data path line to find out where the file is in _current_ context
* Also added something to handle the fact that macOS uses a symlink to /tmp from /private/tmp. 
* From the perspective of the original model path we translate the "../../../..*.csv" line into the absolute path. That's what we now try to load and see if it can be accessed

## Testing
New tests were added. A 4th testing scenario (`metrum_std`) that matches more of what the boilerplate structure for Metrum is. These models (Both a .ctl and a .mod) are tested to make sure they don't generate an error on execution, and that the execution completes. 