### PR TITLE
Feature/concurrent execution hooks

### DIFF
--- a/cmd/local.go
+++ b/cmd/local.go
@@ -315,9 +315,7 @@ func (l LocalModel) Cleanup(channels *turnstile.ChannelMap) {
 
 	PostWorkExecution(&l, l.Nonmem.FileName, channels, l.Cancel)
 
-	log.Info("Waiting for any post execution hooks to finish")
-	executionWaitGroup.Wait()
-
+	log.Infof("%s Cleanup completed", l.Nonmem.LogIdentifier())
 	channels.Completed <- 1
 }
 

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -313,7 +313,7 @@ func (l LocalModel) Cleanup(channels *turnstile.ChannelMap) {
 
 	//PostWorkExecution phase if the script value is not empty
 
-	PostWorkExecution(&l, l.Nonmem.FileName, channels, l.Cancel)
+	PostWorkExecution(&l, l.Nonmem.FileName, channels, l.Cancel, true)
 
 	log.Infof("%s Cleanup completed", l.Nonmem.LogIdentifier())
 	channels.Completed <- 1

--- a/cmd/nonmem.go
+++ b/cmd/nonmem.go
@@ -657,6 +657,11 @@ func newPostWorkInstruction(model *NonMemModel, cleanupExclusions []string, mand
 }
 
 func postWorkNotice(m *turnstile.Manager, t time.Time) {
+
+	//Wait for any post execution processes to finish
+	log.Info("Waiting for any post execution hooks to finish")
+	executionWaitGroup.Wait()
+
 	log.Debug("Work has completed. Beginning detail display via console")
 	if m.Errors > 0 {
 		log.Errorf("%d errors were experienced during the run", m.Errors)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/metrumresearchgroup/babylon/configlib"
@@ -45,13 +46,14 @@ var (
 	debug   bool
 	threads int
 	//Json indicates whether we should have a JSON tree of output
-	Json    bool
-	preview bool
-	noExt   bool
-	noGrd   bool
-	noCov   bool
-	noCor   bool
-	noShk   bool
+	Json               bool
+	preview            bool
+	noExt              bool
+	noGrd              bool
+	noCov              bool
+	noCor              bool
+	noShk              bool
+	executionWaitGroup sync.WaitGroup
 )
 
 // RootCmd represents the base command when called without any subcommands

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -185,10 +185,8 @@ func RecordConcurrentError(model string, notes string, err error, channels *turn
 	cancel <- true
 	channels.Errors <- newConcurrentError(model, notes, err)
 
-	//Handle post executions for errors uniformly in this one place
-	_, newErr := ExecutePostWorkDirectivesWithEnvironment(executor)
+	//TODO: Why are you hanging?
+	//I think it's the deferred cancellation
+	PostWorkExecution(executor, model, channels, cancel)
 
-	if newErr != nil {
-		log.Errorf("A failure occurred trying to perform the post-execution hooks for failure notification: %s", newErr)
-	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -187,6 +187,6 @@ func RecordConcurrentError(model string, notes string, err error, channels *turn
 
 	//TODO: Why are you hanging?
 	//I think it's the deferred cancellation
-	PostWorkExecution(executor, model, channels, cancel)
+	PostWorkExecution(executor, model, channels, cancel, false)
 
 }


### PR DESCRIPTION
Moves the execution to be asynchronous and prevent blocking. Previously, the application would sit and wait on each thread for the requests to the slack API to complete, which could take some time. Now, it's set to the side in a routine, and a global wait group tracks progress. 

At the end, we jus wait to make sure the wait group terminates.