### PR TITLE
fix: dereferencing config before writing yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .idea
 dist
 babylon.log
+babylon.yaml
 !.idea

--- a/configlib/config.go
+++ b/configlib/config.go
@@ -113,19 +113,22 @@ func SaveConfig(configpath string) {
 }
 
 func WriteViperConfig(path string, sge bool, config *Config) error {
-	if sge {
 
+	//Dereference to avoid touching the original values for multiple run targets
+	lc := *config
+
+	if sge {
 		//Set the config to overwrite false and re-write config. This ensures that the local phase will not deal with io contention
 		//around the SGE output streams
 		log.Debug("Updating babylon config to overwrite=false. This avoids IO contention with the grid engine for the next execution round")
-		config.Overwrite = false
-		config.SaveConfig = false
-		config.Local.CreateChildDirs = false
+		lc.Overwrite = false
+		lc.SaveConfig = false
+		lc.Local.CreateChildDirs = false
 	}
 
 	log.Debugf("Requested save of config file %s", path)
 
-	err := config.RenderYamlToFile(path)
+	err := lc.RenderYamlToFile(path)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
Addresses #156 

The overwrites values are correct in initial collection, injection into the model, but periodically could observe the value as false during prepare phase. Realized that it was because the 

```go
func WriteViperConfig(path string, sge bool, config *Config) error {

	//Dereference to avoid touching the original values for multiple run targets
	lc := *config

	if sge {
		//Set the config to overwrite false and re-write config. This ensures that the local phase will not deal with io contention
		//around the SGE output streams
		log.Debug("Updating babylon config to overwrite=false. This avoids IO contention with the grid engine for the next execution round")
		lc.Overwrite = false
		lc.SaveConfig = false
		lc.Local.CreateChildDirs = false
	}

	log.Debugf("Requested save of config file %s", path)

	err := lc.RenderYamlToFile(path)

	if err != nil {
		return err
	}

	return nil
}
```

block previously used a pointer directly (because it was available in the model) and acted directly on it. Now we dereference and manipulate a local copy to avoid unexpected action