### PR TITLE
Fixing failure to hash source model for NMQual

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,6 +22,7 @@
         MPIEXEC_PATH: /usr/bin/mpiexec
         NONMEMROOT: /opt/NONMEM
         NMVERSION: nm74gf
+        NMQUAL: true
         NONMEM_LICENSE:
           from_secret: NONMEM_LICENSE
       image: nmtest

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -175,7 +175,7 @@ func (l LocalModel) Cleanup(channels *turnstile.ChannelMap) {
 	go HashFileOnChannel(dataHashChan, l.Nonmem.DataPath, l.Nonmem.FileName)
 
 	modelHashChan := make(chan string)
-	go HashFileOnChannel(modelHashChan, path.Join(l.Nonmem.OriginalPath, l.Nonmem.Model), l.Nonmem.FileName)
+	go HashFileOnChannel(modelHashChan, path.Join(l.Nonmem.OriginalPath, l.Nonmem.OriginalModel), l.Nonmem.FileName)
 
 	log.Debugf("%s Beginning selection of cleanable / copiable files", l.Nonmem.LogIdentifier())
 	//Magical instructions

--- a/cmd/nonmem.go
+++ b/cmd/nonmem.go
@@ -142,6 +142,8 @@ type NonMemModel struct {
 	BBIVersion string `json:"bbi_version"`
 	//Model is the name of the model on which we will action: acop.mod
 	Model string `json:"model_name"`
+	//OriginalModel is the original filename, primarily used for NMQual or others that require changing filenames
+	OriginalModel string `json:"original_model"`
 	//Path is the Fully Qualified Path to the original model
 	Path string `json:"model_path"`
 	// DataPath is the path to the data when executing the model
@@ -707,6 +709,7 @@ func NewNonMemModel(modelname string, config configlib.Config) (NonMemModel, err
 	}
 
 	lm.Model = fi.Name()
+	lm.OriginalModel = lm.Model
 
 	modelPieces := strings.Split(lm.Model, ".")
 


### PR DESCRIPTION
# Source Problem
When running with`--nmqual`, errors are generated in the output indicating the source model could not be hashed

# Reason
During operation in the local branch, we copy the model, rename it to a `*.ctl`. This is because the NMQual operation requires a filename ending with CTL. At this point, however, we have no stored reference back to the original `.mod` or `.whatever` file.  So the hash tries to find a `.ctl` file in the original source directory (which may not exist). 

# Fix
We already had an `OriginalPath` member of the `NonMemModel` struct, so I added an `OriginalModel` field, which is populated when all of the models are created from arguments. During hashing operations we always go back to the `OriginalPath`/`OriginalModel` to accurately get a model hash. 