### PR TITLE
Goreleaser updates

### DIFF
--- a/cmd/bbi/goreleaser.yml
+++ b/cmd/bbi/goreleaser.yml
@@ -23,9 +23,16 @@ brews:
 builds:
   -
     id: "default"
+    env:
+      - CGO_ENABLED=0
     ldflags:
-      - -s -w -X 'github.com/metrumresearchgroup/babylon/cmd.VERSION={{ .Env.VERSION }}'
-
+      - -s -w -extldflags "-static" -X 'github.com/metrumresearchgroup/babylon/cmd.VERSION={{ .Env.VERSION }}'
+release:
+  github:
+    owner: metrumresearchgroup
+    name: babylon
+    #Turning on auto marking of non standard releases as "pre" releases
+  prerelease: auto
 archives:
   -
     builds:
@@ -33,3 +40,8 @@ archives:
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
     wrap_in_directory: true
     format: tar.gz
+changelog:
+  filters:
+    exclude:
+      - '^ci:'
+      - '^docs:'


### PR DESCRIPTION
Several goreleaser changes:
* Addition of `extldflags -static`
* Addition of CGO_ENABLED=0 variable during build
* Update of release section to automatically mark non standard releases as pre-release
    * This means that the "latest" link will still point to the latest production version
    * v2.1.0 would be a production tag while v2.1.1-rc4 would be marked as pre-release automatically
* Updated the changelog section to exclude commits beginning with `ci:` or `docs:` 

I verified with `2.1.1-rc2` that this now works. The Linux binary works fine as downloaded and also that my `ci:` commit was excluded from the change log. 