### PR TITLE
Making sure the additional environment variables end up in SGE Environment

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -240,6 +241,8 @@ func ExecutePostWorkDirectivesWithEnvironment(worker PostWorkExecutor) (string, 
 	}).Debug("Collected details. Preparing to set environment")
 
 	environment, err := PostExecutionEnvironment(postworkConfig, postWorkEnv)
+
+	environment = append(environment,os.Environ()...)
 
 	log.WithFields(log.Fields{
 		"environment": environment,


### PR DESCRIPTION
* Makes sure that before Qsub operations the provided additional post-work variables are added to the command execution environment for `qsub`
* Makes sure that the environment is appended to execution environment for the post work script
* Also make sure `qsub` uses the full path to the `grid.sh` script as opposed to just navigating to the directory and executing. Removes one more IO concern per operation