### PR TITLE
Refactor/cov cor out

### DIFF
--- a/cmd/covcor.go
+++ b/cmd/covcor.go
@@ -1,0 +1,53 @@
+// Copyright © 2016 Devin Pastoor <devin.pastoor@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	parser "github.com/metrumresearchgroup/babylon/parsers/nmparser"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// runCmd represents the run command
+var covcorCmd = &cobra.Command{
+	Use:   "covcor",
+	Short: "load .cov and .cor output from a model run",
+	Long: `load .cov and .cor output from model(s), for example: 
+bbi nonmem covcor run001/run001
+ `,
+	Run: covcor,
+}
+
+func covcor(cmd *cobra.Command, args []string) {
+	if debug {
+		viper.Debug()
+	}
+
+	results, err := parser.GetCovCorOutput(args[0])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	jsonRes, _ := json.MarshalIndent(results, "", "\t")
+	fmt.Printf("%s\n", jsonRes)
+
+}
+func init() {
+	nonmemCmd.AddCommand(covcorCmd)
+}

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -44,8 +44,8 @@ var (
 var summaryCmd = &cobra.Command{
 	Use:   "summary",
 	Short: "summarize the output of model(s)",
-	Long: `run model(s), for example: 
-nmu summarize run001.lst
+	Long: `summarize model(s), for example: 
+bbi nonmem summary run001/run001.lst
  `,
 	Run: summary,
 }

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -51,7 +51,7 @@ nmu summarize run001.lst
 }
 
 type jsonResults struct {
-	Results []parser.ModelOutput
+	Results []parser.SummaryOutput
 	Errors  []error
 }
 
@@ -60,13 +60,7 @@ func summary(cmd *cobra.Command, args []string) {
 		viper.Debug()
 	}
 	if len(args) == 1 {
-		results, err := parser.GetModelOutput(args[0],
-			parser.NewModelOutputFile(extFile, noExt),
-			!noGrd,
-			!noCov,
-			!noCor,
-			!noShk,
-		)
+		results, err := parser.GetModelOutput(args[0], parser.NewModelOutputFile(extFile, noExt), !noGrd, !noShk, )
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -91,7 +85,7 @@ func summary(cmd *cobra.Command, args []string) {
 		Index   int
 		Outcome result
 		Err     error
-		Result  parser.ModelOutput
+		Result  parser.SummaryOutput
 	}
 
 	workers := runtime.NumCPU()
@@ -111,13 +105,7 @@ func summary(cmd *cobra.Command, args []string) {
 	for w := 1; w <= workers; w++ {
 		go func(w int, modIndex <-chan int, results chan<- modelResult) {
 			for i := range modIndex {
-				r, err := parser.GetModelOutput(args[i],
-					parser.NewModelOutputFile(extFile, noExt),
-					!noGrd,
-					!noCov,
-					!noCor,
-					!noShk,
-				)
+				r, err := parser.GetModelOutput(args[i], parser.NewModelOutputFile(extFile, noExt), !noGrd, !noShk, )
 				if err != nil {
 					results <- modelResult{
 						Index:   i,

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -30,14 +30,8 @@ var (
 	summaryTree bool
 	noExt       bool
 	noGrd       bool
-	noCov       bool
-	noCor       bool
 	noShk       bool
 	extFile     string
-	grdFile     string
-	covFile     string
-	corFile     string
-	shkFile     string
 )
 
 // runCmd represents the run command
@@ -167,8 +161,6 @@ func init() {
 	//Used for Summary
 	summaryCmd.PersistentFlags().BoolVar(&noExt, "no-ext-file", false, "do not use ext file")
 	summaryCmd.PersistentFlags().BoolVar(&noGrd, "no-grd-file", false, "do not use grd file")
-	summaryCmd.PersistentFlags().BoolVar(&noCov, "no-cov-file", false, "do not use cov file")
-	summaryCmd.PersistentFlags().BoolVar(&noCor, "no-cor-file", false, "do not use cor file")
 	summaryCmd.PersistentFlags().BoolVar(&noShk, "no-shk-file", false, "do not use shk file")
 	summaryCmd.PersistentFlags().StringVar(&extFile, "ext-file", "", "name of custom ext-file")
 }

--- a/parsers/nmparser/get_model_output.go
+++ b/parsers/nmparser/get_model_output.go
@@ -61,13 +61,13 @@ func GetModelOutput(lstPath string, ext ModelOutputFile, grd bool, shk bool) (Su
 	if err != nil {
 		// this is set to trace as don't want it to log normally as could screw up json output that
 		// requests results from this such as summary --json
-		log.Trace("error reading cpu file: %v", err)
+		log.Trace("error reading cpu file: ", err)
 	} else {
 		results.RunDetails.OutputFilesUsed = append(results.RunDetails.OutputFilesUsed, filepath.Base(cpuFilePath))
 		cpuTime, err := strconv.ParseFloat(strings.TrimSpace(cpuLines[0]), 64)
 		if err != nil {
 			// this is set to trace as don't want it to log normally as could screw up json output that
-			log.Trace("error parsing cpu time: %v", err)
+			log.Trace("error parsing cpu time: ", err)
 			results.RunDetails.CpuTime = DefaultFloat64
 		}
 		results.RunDetails.CpuTime = cpuTime

--- a/parsers/nmparser/parse_lst_file.go
+++ b/parsers/nmparser/parse_lst_file.go
@@ -319,7 +319,7 @@ func getGradientLine(lines []string, start int) string {
 }
 
 // ParseLstEstimationFile parses the lst file
-func ParseLstEstimationFile(lines []string) ModelOutput {
+func ParseLstEstimationFile(lines []string) SummaryOutput {
 	ofvDetails := NewOfvDetails()
 	runHeuristics := NewRunHeuristics()
 	var finalParameterEstimatesIndex int
@@ -408,7 +408,7 @@ func ParseLstEstimationFile(lines []string) ModelOutput {
 	// 	parameterNames = ParseParameterNames(lines[startThetaIndex:endSigmaIndex])
 	// }
 	// TODO re-replace parameter data from lst
-	result := ModelOutput{
+	result := SummaryOutput{
 		RunHeuristics: runHeuristics,
 		RunDetails:    ParseRunDetails(lines),
 		ParametersData: []ParametersData{

--- a/parsers/nmparser/parse_run_details_test.go
+++ b/parsers/nmparser/parse_run_details_test.go
@@ -37,6 +37,7 @@ var RunDetails01Results = RunDetails{
 	"Tue Dec 17 18:11:32 2013",
 	6.84,
 	3.34,
+	10.5, // this is made up, not for an actual run output
 	352,
 	3.4,
 	"3.mod, double inital estimates",
@@ -46,7 +47,7 @@ var RunDetails01Results = RunDetails{
 	50,
 	442,
 	492,
-	"-999999999",
+	[]string{"-999999999"},
 	[]string{""},
 }
 
@@ -58,6 +59,7 @@ var RunDetails02Results = RunDetails{
 	"Fri Jul 12 09:27:20 EDT 2019",
 	0.68,
 	0.02,
+	10.5, // this is made up, not for an actual run output
 	178,
 	3.1,
 	"1 model, 1 comp",
@@ -67,7 +69,7 @@ var RunDetails02Results = RunDetails{
 	50,
 	442,
 	492,
-	"",
+	[]string{""},
 	[]string{""},
 }
 

--- a/parsers/nmparser/set_missing_values_to_default.go
+++ b/parsers/nmparser/set_missing_values_to_default.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-func setMissingValuesToDefault(results *ModelOutput, etaCount, epsCount int) {
+func setMissingValuesToDefault(results *SummaryOutput, etaCount, epsCount int) {
 	// method name
 	for i := range results.ParametersData {
 		if len(results.ParametersData[i].Method) == 0 {

--- a/parsers/nmparser/set_missing_values_to_default_test.go
+++ b/parsers/nmparser/set_missing_values_to_default_test.go
@@ -9,19 +9,19 @@ import (
 
 func TestSetMissingValuesToDefaultParameterDataMethod(t *testing.T) {
 	var tests = []struct {
-		modelOutput ModelOutput
+		modelOutput SummaryOutput
 		etaCount    int
 		epsCount    int
 		expected    string
 	}{
 		{
-			modelOutput: ModelOutput{
+			modelOutput: SummaryOutput{
 				ParametersData: []ParametersData{ParametersData{}},
 			},
 			expected: "METHOD NOT DETECTED",
 		},
 		{
-			modelOutput: ModelOutput{
+			modelOutput: SummaryOutput{
 				ParametersData: []ParametersData{ParametersData{
 					Method: "Test Method",
 				}},
@@ -37,14 +37,14 @@ func TestSetMissingValuesToDefaultParameterDataMethod(t *testing.T) {
 
 func TestSetMissingValuesToDefaultParameterDataStdErrDimension(t *testing.T) {
 	var tests = []struct {
-		modelOutput ModelOutput
+		modelOutput SummaryOutput
 		etaCount    int
 		epsCount    int
 		expected    int
 		context     string
 	}{
 		{
-			modelOutput: ModelOutput{
+			modelOutput: SummaryOutput{
 				ParametersData: []ParametersData{ParametersData{
 					Estimates: ParametersResult{
 						Theta: []float64{1, 2, 4},
@@ -65,14 +65,14 @@ func TestSetMissingValuesToDefaultParameterDataStdErrDimension(t *testing.T) {
 
 func TestSetMissingValuesToDefaultParameterDataRESDDimension(t *testing.T) {
 	var tests = []struct {
-		modelOutput ModelOutput
+		modelOutput SummaryOutput
 		etaCount    int
 		epsCount    int
 		expected    int
 		context     string
 	}{
 		{
-			modelOutput: ModelOutput{
+			modelOutput: SummaryOutput{
 				ParametersData: []ParametersData{ParametersData{
 					Estimates: ParametersResult{
 						Omega: []float64{1, 2, 4},
@@ -93,14 +93,14 @@ func TestSetMissingValuesToDefaultParameterDataRESDDimension(t *testing.T) {
 
 func TestSetMissingValuesToDefaultParameterDataValues(t *testing.T) {
 	var tests = []struct {
-		modelOutput ModelOutput
+		modelOutput SummaryOutput
 		etaCount    int
 		epsCount    int
 		expected    int
 		context     string
 	}{
 		{
-			modelOutput: ModelOutput{
+			modelOutput: SummaryOutput{
 				ParametersData: []ParametersData{ParametersData{
 					Estimates: ParametersResult{
 						Omega: []float64{1, 2, 4},
@@ -127,14 +127,14 @@ func TestSetMissingValuesToDefaultParameterDataValues(t *testing.T) {
 
 func TestSetMissingValuesToDefaultParameterNameValues(t *testing.T) {
 	var tests = []struct {
-		modelOutput ModelOutput
+		modelOutput SummaryOutput
 		etaCount    int
 		epsCount    int
 		expected    int
 		context     string
 	}{
 		{
-			modelOutput: ModelOutput{
+			modelOutput: SummaryOutput{
 				ParametersData: []ParametersData{ParametersData{
 					Estimates: ParametersResult{
 						Theta: []float64{1, 2, 4},
@@ -156,14 +156,14 @@ func TestSetMissingValuesToDefaultParameterNameValues(t *testing.T) {
 
 func TestSetMissingValuesToDefaultShrinkageEta(t *testing.T) {
 	var tests = []struct {
-		modelOutput ModelOutput
+		modelOutput SummaryOutput
 		etaCount    int
 		epsCount    int
 		expected    int
 		context     string
 	}{
 		{
-			modelOutput: ModelOutput{
+			modelOutput: SummaryOutput{
 				ParametersData: []ParametersData{ParametersData{
 					Estimates: ParametersResult{},
 				}},
@@ -182,14 +182,14 @@ func TestSetMissingValuesToDefaultShrinkageEta(t *testing.T) {
 
 func TestSetMissingValuesToDefaultShrinkageEps(t *testing.T) {
 	var tests = []struct {
-		modelOutput ModelOutput
+		modelOutput SummaryOutput
 		etaCount    int
 		epsCount    int
 		expected    int
 		context     string
 	}{
 		{
-			modelOutput: ModelOutput{
+			modelOutput: SummaryOutput{
 				ParametersData: []ParametersData{ParametersData{
 					Estimates: ParametersResult{},
 				}},

--- a/parsers/nmparser/structs.go
+++ b/parsers/nmparser/structs.go
@@ -140,7 +140,6 @@ type SummaryOutput struct {
 }
 
 // CovCorOutput is the output from parsing the .cov and .cor file
-// TODO: We haven't collected a lot of feedback on this, may get refactored later
 type CovCorOutput struct {
 	CovarianceTheta  []FlatArray          `json:"covariance_theta,omitempty"`
 	CorrelationTheta []FlatArray          `json:"correlation_theta,omitempty"`

--- a/parsers/nmparser/structs.go
+++ b/parsers/nmparser/structs.go
@@ -128,8 +128,8 @@ type OfvDetails struct {
 	OFVWithConstant float64 `json:"ofv_with_constant,omitempty"`
 }
 
-// ModelOutput is the output struct from a lst file
-type ModelOutput struct {
+// SummaryOutput is the output struct from a lst file
+type SummaryOutput struct {
 	RunDetails       RunDetails           `json:"run_details,omitempty"`
 	RunHeuristics    RunHeuristics        `json:"run_heuristics,omitempty"`
 	ParametersData   []ParametersData     `json:"parameters_data,omitempty"`
@@ -137,6 +137,11 @@ type ModelOutput struct {
 	OFV              OfvDetails           `json:"ofv,omitempty"`
 	ConditionNumber  float64              `json:"condition_number,omitempty"`
 	ShrinkageDetails [][]ShrinkageDetails `json:"shrinkage_details,omitempty"`
+}
+
+// CovCorOutput is the output from parsing the .cov and .cor file
+// TODO: We haven't collected a lot of feedback on this, may get refactored later
+type CovCorOutput struct {
 	CovarianceTheta  []FlatArray          `json:"covariance_theta,omitempty"`
 	CorrelationTheta []FlatArray          `json:"correlation_theta,omitempty"`
 }

--- a/parsers/nmparser/summary.go
+++ b/parsers/nmparser/summary.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Summary prints all results from the parsed LstData
-func (results ModelOutput) Summary() bool {
+func (results SummaryOutput) Summary() bool {
 	thetaTable := tablewriter.NewWriter(os.Stdout)
 	thetaTable.SetAlignment(tablewriter.ALIGN_LEFT)
 	thetaTable.SetColWidth(100)


### PR DESCRIPTION
Refactoring the `bbi nonmem summary` call to make the following changes:

* `bbi nonmem summary` will no longer parse the `.cov` and `.cor` files
  * Take the `.cov` and `.cor` output out of the summary json
* Create new command to extract the information from those files into a separate json.