### PR TITLE
release 2.3.0 merging to master

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,6 +22,7 @@ steps:
       - if [ -d /tmp/${DRONE_BUILD_NUMBER}/babylontest ] ; then rm -rf /tmp/${DRONE_BUILD_NUMBER}/babylontest; fi
   - name: Build Babylon
     commands:
+      - mkdir -p /tmp/${DRONE_BUILD_NUMBER} ; git rev-parse HEAD > /tmp/${DRONE_BUILD_NUMBER}/bbi_hash
       - go build -o bbi cmd/bbi/main.go
       - ./bbi version
   - name: Get BabylonTest
@@ -30,7 +31,15 @@ steps:
     commands:
       - git clone https://github.com/metrumresearchgroup/babylontest.git /tmp/${DRONE_BUILD_NUMBER}/babylontest
       - cd /tmp/${DRONE_BUILD_NUMBER}/babylontest
+      - mkdir -p /tmp/${DRONE_BUILD_NUMBER} ; git rev-parse HEAD > /tmp/${DRONE_BUILD_NUMBER}/babylontest_hash
       - if [ ! -z $BABYLONTEST_BRANCH ]; then git checkout $BABYLONTEST_BRANCH; fi
+  - name: Copy commit hashes to s3
+    commands:
+      - printf "[\n" > /tmp/${DRONE_BUILD_NUMBER}/commits.json
+      - printf "  {\"repo\":\"metrumresearchgroup/babylon\", \"commit\":\"$(cat /tmp/${DRONE_BUILD_NUMBER}/bbi_hash)\"},\n" >> /tmp/${DRONE_BUILD_NUMBER}/commits.json
+      - printf "  {\"repo\":\"metrumresearchgroup/babylontest\", \"commit\":\"$(cat /tmp/${DRONE_BUILD_NUMBER}/babylontest_hash)\"}\n" >> /tmp/${DRONE_BUILD_NUMBER}/commits.json
+      - printf "]\n" >> /tmp/${DRONE_BUILD_NUMBER}/commits.json
+      - aws s3 cp /tmp/${DRONE_BUILD_NUMBER}/commits.json s3://mrg-validation/babylon/${DRONE_BUILD_NUMBER}/commits.json
   - name: Test
     environment:
       <<: *sge_environment
@@ -57,9 +66,13 @@ steps:
       - cd /tmp/${DRONE_BUILD_NUMBER}/babylontest
       - export ROOT_EXECUTION_DIR=/data/${DRONE_BUILD_NUMBER}
       - export BABYLON_GRID_NAME_PREFIX="drone_${DRONE_BUILD_NUMBER}"
+      #Run test suite and copy results to s3
       - bbi init --dir /opt/NONMEM
-      - go test ./... -v --json --timeout 30m | tee test_output.json
+      - go test ./... -v --json -timeout 30m | tee test_output.json
       - aws s3 cp test_output.json s3://mrg-validation/babylon/${DRONE_BUILD_NUMBER}/results.json
+      #Check for test failures and clean up
+      - chmod +x failure_detector.sh
+      - ./failure_detector.sh test_output.json
       - rm -rf /data/${DRONE_BUILD_NUMBER}
       - rm -rf /tmp/${DRONE_BUILD_NUMBER}/babylontest
   - name: Cleanup on failure
@@ -102,7 +115,8 @@ steps:
       - mkdir testoutput
       - mkdir rendered
       - aws s3 cp s3://mrg-validation/babylon/${DRONE_BUILD_NUMBER}/results.json testoutput/results.json
-      - ./gpv --scenarioFile validation.json --testsDirectory testoutput --outputDirectory rendered
+      - aws s3 cp s3://mrg-validation/babylon/${DRONE_BUILD_NUMBER}/commits.json commits.json
+      - ./gpv --scenarioFile validation.json --commitsFile commits.json --testsDirectory testoutput --outputDirectory rendered
       - aws s3 cp rendered/specification.md s3://mrg-validation/babylon/${DRONE_TAG}/specification.md
       - aws s3 cp rendered/testing_and_validation.md s3://mrg-validation/babylon/${DRONE_TAG}/testing_and_validation.md
       - aws s3 cp rendered/traceability_matrix.md s3://mrg-validation/babylon/${DRONE_TAG}/traceability_matrix.md

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist
 babylon.log
 babylon.yaml
+main

--- a/cmd/covcor.go
+++ b/cmd/covcor.go
@@ -1,0 +1,53 @@
+// Copyright © 2016 Devin Pastoor <devin.pastoor@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	parser "github.com/metrumresearchgroup/babylon/parsers/nmparser"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// runCmd represents the run command
+var covcorCmd = &cobra.Command{
+	Use:   "covcor",
+	Short: "load .cov and .cor output from a model run",
+	Long: `load .cov and .cor output from model(s), for example: 
+bbi nonmem covcor run001/run001
+ `,
+	Run: covcor,
+}
+
+func covcor(cmd *cobra.Command, args []string) {
+	if debug {
+		viper.Debug()
+	}
+
+	results, err := parser.GetCovCorOutput(args[0])
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	jsonRes, _ := json.MarshalIndent(results, "", "\t")
+	fmt.Printf("%s\n", jsonRes)
+
+}
+func init() {
+	nonmemCmd.AddCommand(covcorCmd)
+}

--- a/cmd/covcor.go
+++ b/cmd/covcor.go
@@ -24,13 +24,15 @@ import (
 	"github.com/spf13/viper"
 )
 
+const covcorLongDescription string = `load .cov and .cor output from model(s), for example: 
+bbi nonmem covcor run001/run001
+bbi nonmem covcor run001/run001.cov
+ `
 // runCmd represents the run command
 var covcorCmd = &cobra.Command{
 	Use:   "covcor",
 	Short: "load .cov and .cor output from a model run",
-	Long: `load .cov and .cor output from model(s), for example: 
-bbi nonmem covcor run001/run001
- `,
+	Long: covcorLongDescription,
 	Run: covcor,
 }
 

--- a/cmd/nonmem.go
+++ b/cmd/nonmem.go
@@ -167,21 +167,18 @@ type NonMemModel struct {
 	Error error `json:"error"`
 }
 
+var nonmemLongDescription string = fmt.Sprintf("\n%s\n\n%s\n\n%s\n", runLongDescription, summaryLongDescription, covcorLongDescription)
+
 // RunCmd represents the run command
 var nonmemCmd = &cobra.Command{
 	Use:   "nonmem",
 	Short: "nonmem a (set of) models locally or on the grid",
-	Long: `run nonmem model(s), for example: 
-bbi nonmem <local|sge> run001.mod
-bbi nonmem  --clean_lvl=1 <local|sge> run001.mod run002.mod
-bbi nonmem run <local|sge> [001:006].mod // expand to run001.mod run002.mod ... run006.mod local
-bbi nonmem run <local|sge> .// run all models in directory
- `,
+	Long: nonmemLongDescription,
 	Run: nonmem,
 }
 
 func nonmem(cmd *cobra.Command, args []string) {
-	println(runLongDescription)
+	println(nonmemLongDescription)
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,11 +48,6 @@ var (
 	//Json indicates whether we should have a JSON tree of output
 	Json               bool
 	preview            bool
-	noExt              bool
-	noGrd              bool
-	noCov              bool
-	noCor              bool
-	noShk              bool
 	executionWaitGroup sync.WaitGroup
 )
 
@@ -98,12 +93,6 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&Json, "json", false, "json tree of output, if possible")
 	viper.BindPFlag("json", RootCmd.PersistentFlags().Lookup("json")) //Bind to viper
 	RootCmd.PersistentFlags().BoolVarP(&preview, "preview", "p", false, "preview action, but don't actually run command")
-	//Used for Summary
-	RootCmd.PersistentFlags().BoolVarP(&noExt, "no-ext-file", "", false, "do not use ext file")
-	RootCmd.PersistentFlags().BoolVarP(&noGrd, "no-grd-file", "", false, "do not use grd file")
-	RootCmd.PersistentFlags().BoolVarP(&noCov, "no-cov-file", "", false, "do not use cov file")
-	RootCmd.PersistentFlags().BoolVarP(&noCor, "no-cor-file", "", false, "do not use cor file")
-	RootCmd.PersistentFlags().BoolVarP(&noShk, "no-shk-file", "", false, "do not use shk file")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -33,14 +33,17 @@ var (
 	noShk       bool
 	extFile     string
 )
+const summaryLongDescription string = `summarize model(s), for example: 
+bbi nonmem summary run001/run001
+bbi nonmem summary run001/run001.lst
+bbi nonmem summary run001/run001.res
+ `
 
 // runCmd represents the run command
 var summaryCmd = &cobra.Command{
 	Use:   "summary",
 	Short: "summarize the output of model(s)",
-	Long: `summarize model(s), for example: 
-bbi nonmem summary run001/run001.lst
- `,
+	Long: summaryLongDescription,
 	Run: summary,
 }
 
@@ -67,7 +70,7 @@ func summary(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	// if we are going to parse mutiple models, we need to reasonably handle failures. The objective
+	// if we are going to parse multiple models, we need to reasonably handle failures. The objective
 	// will be to always return a json object if its json, and if not, error as soon as it hits a printed issue.
 	// As such, the idea will be to store results such they can be filtered
 	type result int

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -30,28 +30,22 @@ var (
 	summaryTree bool
 	noExt       bool
 	noGrd       bool
-	noCov       bool
-	noCor       bool
 	noShk       bool
 	extFile     string
-	grdFile     string
-	covFile     string
-	corFile     string
-	shkFile     string
 )
 
 // runCmd represents the run command
 var summaryCmd = &cobra.Command{
 	Use:   "summary",
 	Short: "summarize the output of model(s)",
-	Long: `run model(s), for example: 
-nmu summarize run001.lst
+	Long: `summarize model(s), for example: 
+bbi nonmem summary run001/run001.lst
  `,
 	Run: summary,
 }
 
 type jsonResults struct {
-	Results []parser.ModelOutput
+	Results []parser.SummaryOutput
 	Errors  []error
 }
 
@@ -60,13 +54,7 @@ func summary(cmd *cobra.Command, args []string) {
 		viper.Debug()
 	}
 	if len(args) == 1 {
-		results, err := parser.GetModelOutput(args[0],
-			parser.NewModelOutputFile(extFile, noExt),
-			!noGrd,
-			!noCov,
-			!noCor,
-			!noShk,
-		)
+		results, err := parser.GetModelOutput(args[0], parser.NewModelOutputFile(extFile, noExt), !noGrd, !noShk, )
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -91,7 +79,7 @@ func summary(cmd *cobra.Command, args []string) {
 		Index   int
 		Outcome result
 		Err     error
-		Result  parser.ModelOutput
+		Result  parser.SummaryOutput
 	}
 
 	workers := runtime.NumCPU()
@@ -111,13 +99,7 @@ func summary(cmd *cobra.Command, args []string) {
 	for w := 1; w <= workers; w++ {
 		go func(w int, modIndex <-chan int, results chan<- modelResult) {
 			for i := range modIndex {
-				r, err := parser.GetModelOutput(args[i],
-					parser.NewModelOutputFile(extFile, noExt),
-					!noGrd,
-					!noCov,
-					!noCor,
-					!noShk,
-				)
+				r, err := parser.GetModelOutput(args[i], parser.NewModelOutputFile(extFile, noExt), !noGrd, !noShk, )
 				if err != nil {
 					results <- modelResult{
 						Index:   i,
@@ -179,8 +161,6 @@ func init() {
 	//Used for Summary
 	summaryCmd.PersistentFlags().BoolVar(&noExt, "no-ext-file", false, "do not use ext file")
 	summaryCmd.PersistentFlags().BoolVar(&noGrd, "no-grd-file", false, "do not use grd file")
-	summaryCmd.PersistentFlags().BoolVar(&noCov, "no-cov-file", false, "do not use cov file")
-	summaryCmd.PersistentFlags().BoolVar(&noCor, "no-cor-file", false, "do not use cor file")
 	summaryCmd.PersistentFlags().BoolVar(&noShk, "no-shk-file", false, "do not use shk file")
 	summaryCmd.PersistentFlags().StringVar(&extFile, "ext-file", "", "name of custom ext-file")
 }

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -17,40 +17,170 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-
 	parser "github.com/metrumresearchgroup/babylon/parsers/nmparser"
+	log "github.com/sirupsen/logrus"
+	"os"
+	"runtime"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-var summaryTree bool
+var (
+	summaryTree bool
+	noExt       bool
+	noGrd       bool
+	noCov       bool
+	noCor       bool
+	noShk       bool
+	extFile     string
+	grdFile     string
+	covFile     string
+	corFile     string
+	shkFile     string
+)
 
 // runCmd represents the run command
 var summaryCmd = &cobra.Command{
 	Use:   "summary",
-	Short: "summarize the output of a model",
+	Short: "summarize the output of model(s)",
 	Long: `run model(s), for example: 
 nmu summarize run001.lst
  `,
 	Run: summary,
 }
 
+type jsonResults struct {
+	Results []parser.ModelOutput
+	Errors  []error
+}
+
 func summary(cmd *cobra.Command, args []string) {
 	if debug {
 		viper.Debug()
 	}
-
-	results := parser.GetModelOutput(args[0], verbose, noExt, noGrd, noCov, noCor, noShk)
-
-	if Json {
-		jsonRes, _ := json.MarshalIndent(results, "", "\t")
-		fmt.Printf("%s\n", jsonRes)
-	} else {
-		results.Summary()
+	if len(args) == 1 {
+		results, err := parser.GetModelOutput(args[0],
+			parser.NewModelOutputFile(extFile, noExt),
+			!noGrd,
+			!noCov,
+			!noCor,
+			!noShk,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if Json {
+			jsonRes, _ := json.MarshalIndent(results, "", "\t")
+			fmt.Printf("%s\n", jsonRes)
+		} else {
+			results.Summary()
+		}
+		return
 	}
 
+	// if we are going to parse mutiple models, we need to reasonably handle failures. The objective
+	// will be to always return a json object if its json, and if not, error as soon as it hits a printed issue.
+	// As such, the idea will be to store results such they can be filtered
+	type result int
+	const (
+		SUCCESS result = 1
+		ERROR          = 2
+	)
+	type modelResult struct {
+		Index   int
+		Outcome result
+		Err     error
+		Result  parser.ModelOutput
+	}
+
+	workers := runtime.NumCPU()
+	if workers < 4 {
+		workers = 4
+	}
+
+	numModels := len(args)
+	if workers > numModels {
+		workers = numModels
+	}
+	models := make(chan int, numModels)
+	results := make(chan modelResult, numModels)
+	orderedResults := make([]modelResult, numModels)
+	var modelResults jsonResults
+
+	for w := 1; w <= workers; w++ {
+		go func(w int, modIndex <-chan int, results chan<- modelResult) {
+			for i := range modIndex {
+				r, err := parser.GetModelOutput(args[i],
+					parser.NewModelOutputFile(extFile, noExt),
+					!noGrd,
+					!noCov,
+					!noCor,
+					!noShk,
+				)
+				if err != nil {
+					results <- modelResult{
+						Index:   i,
+						Outcome: ERROR,
+						Err:     err,
+						Result:  r,
+					}
+				} else {
+					results <- modelResult{
+						Index:   i,
+						Outcome: SUCCESS,
+						Err:     err,
+						Result:  r,
+					}
+				}
+			}
+		}(w, models, results)
+	}
+	for m := 0; m < numModels; m++ {
+		models <- m
+	}
+	close(models)
+	for r := 0; r < numModels; r++ {
+		res := <-results
+		orderedResults[res.Index] = res
+	}
+	for _, res := range orderedResults {
+		if res.Outcome == SUCCESS {
+			modelResults.Results = append(modelResults.Results, res.Result)
+		} else if res.Outcome == ERROR {
+			modelResults.Errors = append(modelResults.Errors, res.Err)
+		}
+	}
+	if Json {
+		jsonRes, _ := json.MarshalIndent(modelResults, "", "\t")
+		fmt.Printf("%s\n", jsonRes)
+		return
+	}
+
+
+	// not json lets print all successful models first then any errors
+	for i, res := range modelResults.Results {
+		res.Summary()
+		// add some spacing between models
+		if i != len(modelResults.Results) -1 {
+			fmt.Println("")
+			fmt.Println("")
+		}
+	}
+	for _, res := range modelResults.Errors {
+		log.Error(res)
+	}
+	if len(modelResults.Errors) > 0 {
+		os.Exit(1)
+	}
 }
 func init() {
 	nonmemCmd.AddCommand(summaryCmd)
+	//Used for Summary
+	summaryCmd.PersistentFlags().BoolVar(&noExt, "no-ext-file", false, "do not use ext file")
+	summaryCmd.PersistentFlags().BoolVar(&noGrd, "no-grd-file", false, "do not use grd file")
+	summaryCmd.PersistentFlags().BoolVar(&noCov, "no-cov-file", false, "do not use cov file")
+	summaryCmd.PersistentFlags().BoolVar(&noCor, "no-cor-file", false, "do not use cor file")
+	summaryCmd.PersistentFlags().BoolVar(&noShk, "no-shk-file", false, "do not use shk file")
+	summaryCmd.PersistentFlags().StringVar(&extFile, "ext-file", "", "name of custom ext-file")
 }

--- a/parsers/nmparser/get_model_output.go
+++ b/parsers/nmparser/get_model_output.go
@@ -1,9 +1,11 @@
 package parser
 
 import (
+	"errors"
+	"fmt"
 	"github.com/thoas/go-funk"
-	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/metrumresearchgroup/babylon/utils"
@@ -11,21 +13,38 @@ import (
 	"github.com/spf13/afero"
 )
 
+// ModelOutputFile gives the name of the summary file and whether to include the data
+// in the model output
+type ModelOutputFile struct {
+	Exclude bool
+	Name    string
+}
+
+// NewModelOutputFile returns a ModelOutputFile with a name and exclusion
+// given no name is set, downstream code should expect standard naming conventions following root.extension syntax
+// for example given a model 100 and want to set the ext file
+// if ModelOutputFile.Name is "" should look for 100.ext
+func NewModelOutputFile(name string, exclude bool) ModelOutputFile {
+	return ModelOutputFile{Name: name, Exclude: exclude}
+}
+
 // GetModelOutput populates and returns a ModelOutput object by parsing files
-// ParameterData is parsed from the ext file when useExtFile is true
-// ParameterData is parsed from the lst file when useExtFile is false
-func GetModelOutput(filePath string, verbose, noExt, noGrd, noCov, noCor, noShk bool) ModelOutput {
+// if ext file is excluded, will attempt to parse the lst file for additional information traditionally available there
+func GetModelOutput(lstPath string, ext ModelOutputFile, grd bool, cov bool, cor bool, shk bool) (ModelOutput, error) {
 
 	AppFs := afero.NewOsFs()
-	runNum, _ := utils.FileAndExt(filePath)
-	dir, _ := filepath.Abs(filepath.Dir(filePath))
-	outputFilePath := strings.Join([]string{filepath.Join(dir, runNum), ".lst"}, "")
-
-	if verbose {
-		log.Printf("base dir: %s", dir)
+	runNum, extension := utils.FileAndExt(lstPath)
+	if extension == "" {
+		// though lst is vastly more used, some examples from ICON use .res
+		extension = ".lst"
 	}
+	dir, _ := filepath.Abs(filepath.Dir(lstPath))
+	outputFilePath := strings.Join([]string{filepath.Join(dir, runNum), extension}, "")
 
-	fileLines, _ := utils.ReadLinesFS(AppFs, outputFilePath)
+	fileLines, err := utils.ReadLinesFS(AppFs, outputFilePath)
+	if err != nil {
+		return ModelOutput{}, err
+	}
 	results := ParseLstEstimationFile(fileLines)
 	results.RunDetails.OutputFilesUsed = append(results.RunDetails.OutputFilesUsed, filepath.Base(outputFilePath))
 	// if bayesian, not aware of any times people ever do a prelim estimation with a different method
@@ -34,15 +53,38 @@ func GetModelOutput(filePath string, verbose, noExt, noGrd, noCov, noCor, noShk 
 		"Importance Sampling assisted by MAP Estimation",
 		"Importance Sampling",
 		"NUTS Bayesian Analysis",
-	} , results.RunDetails.EstimationMethods[len(results.RunDetails.EstimationMethods) - 1])
+		"Objective Function Evaluation by Importance Sampling",
+	}, results.RunDetails.EstimationMethods[len(results.RunDetails.EstimationMethods)-1])
 
-	log.Printf("gradient method?: %s, method detected: %s \n", isNotGradientBased, results.RunDetails.EstimationMethods[len(results.RunDetails.EstimationMethods) - 1])
+	cpuFilePath := filepath.Join(dir, runNum+".cpu")
+	cpuLines, err := utils.ReadLines(cpuFilePath)
+	if err != nil {
+		// this is set to trace as don't want it to log normally as could screw up json output that
+		// requests results from this such as summary --json
+		log.Trace("error reading cpu file: %v", err)
+	} else {
+		results.RunDetails.OutputFilesUsed = append(results.RunDetails.OutputFilesUsed, filepath.Base(cpuFilePath))
+		cpuTime, err := strconv.ParseFloat(strings.TrimSpace(cpuLines[0]), 64)
+		if err != nil {
+			// this is set to trace as don't want it to log normally as could screw up json output that
+			log.Trace("error parsing cpu time: %v", err)
+			results.RunDetails.CpuTime = DefaultFloat64
+		}
+		results.RunDetails.CpuTime = cpuTime
+	}
 
-	if !noExt {
-		extFilePath := strings.Join([]string{filepath.Join(dir, runNum), ".ext"}, "")
+	if !ext.Exclude {
+		if ext.Name == "" {
+			ext.Name = runNum + ".ext"
+		}
+		extFilePath := filepath.Join(dir, ext.Name)
+		err := errorIfNotExists(AppFs, extFilePath, "--no-ext-file")
+		if err != nil {
+			return ModelOutput{}, err
+		}
 		extLines, err := utils.ReadParamsAndOutputFromExt(extFilePath)
 		if err != nil {
-			panic(err)
+			return ModelOutput{}, err
 		}
 		extData, parameterNames := ParseExtData(ParseExtLines(extLines))
 		results.ParametersData = extData
@@ -52,54 +94,84 @@ func GetModelOutput(filePath string, verbose, noExt, noGrd, noCov, noCor, noShk 
 		results.RunDetails.OutputFilesUsed = append(results.RunDetails.OutputFilesUsed, filepath.Base(extFilePath))
 	}
 
-	if !noGrd && !isNotGradientBased {
-		grdFilePath := strings.Join([]string{filepath.Join(dir, runNum), ".grd"}, "")
+	if grd && !isNotGradientBased {
+		name := runNum + ".grd"
+		grdFilePath := filepath.Join(dir, name)
+		err := errorIfNotExists(AppFs, grdFilePath, "--no-grd-file")
+		if err != nil {
+			return ModelOutput{}, err
+		}
 		grdLines, err := utils.ReadLinesFS(AppFs, grdFilePath)
 		if err != nil {
-			if os.IsNotExist(err) {
-				log.Error("no gradient file exists at: " + grdFilePath)
-			} else {
-				panic(err)
-			}
+			return ModelOutput{}, err
 		}
 		parametersData, _ := ParseGrdData(ParseGrdLines(grdLines))
 		results.RunHeuristics.HasFinalZeroGradient = HasZeroGradient(parametersData[len(parametersData)-1].Fixed.Theta)
 		results.RunDetails.OutputFilesUsed = append(results.RunDetails.OutputFilesUsed, filepath.Base(grdFilePath))
 	}
 
-	if !noCov {
-		covFilePath := strings.Join([]string{filepath.Join(dir, runNum), ".cov"}, "")
-		covLines, err := utils.ReadLines(covFilePath)
-		if err == nil {
-			results.CovarianceTheta = GetThetaValues(covLines)
-			results.RunDetails.OutputFilesUsed = append(results.RunDetails.OutputFilesUsed, filepath.Base(covFilePath))
+	if cov {
+		name := runNum + ".cov"
+		covFilePath := filepath.Join(dir, name)
+		err := errorIfNotExists(AppFs, covFilePath, "--no-cov-file")
+		if err != nil {
+			return ModelOutput{}, err
 		}
+		covLines, err := utils.ReadLines(covFilePath)
+		if err != nil {
+			return ModelOutput{}, err
+		}
+		results.CovarianceTheta = GetThetaValues(covLines)
+		results.RunDetails.OutputFilesUsed = append(results.RunDetails.OutputFilesUsed, filepath.Base(covFilePath))
 	}
 
-	if !noCor {
-		corFilePath := strings.Join([]string{filepath.Join(dir, runNum), ".cor"}, "")
-		corLines, err := utils.ReadLines(corFilePath)
-		if err == nil {
-			results.CorrelationTheta = GetThetaValues(corLines)
-			results.RunDetails.OutputFilesUsed = append(results.RunDetails.OutputFilesUsed, filepath.Base(corFilePath))
+	if cor {
+		name := runNum + ".cor"
+		corFilePath := filepath.Join(dir, name)
+		err := errorIfNotExists(AppFs, corFilePath, "--no-cor-file")
+		if err != nil {
+			return ModelOutput{}, err
 		}
+		corLines, err := utils.ReadLines(corFilePath)
+		if err != nil {
+			return ModelOutput{}, err
+		}
+		results.CorrelationTheta = GetThetaValues(corLines)
+		results.RunDetails.OutputFilesUsed = append(results.RunDetails.OutputFilesUsed, filepath.Base(corFilePath))
 	}
+
 	etaCount := lowerDiagonalLengthToDimension[len(results.ParametersData[len(results.ParametersData)-1].Estimates.Omega)]
 	epsCount := lowerDiagonalLengthToDimension[len(results.ParametersData[len(results.ParametersData)-1].Estimates.Sigma)]
 	// bayesian model runs will never have shrinkage files
-	if !noShk && !isNotGradientBased {
-		shkFilePath := strings.Join([]string{filepath.Join(dir, runNum), ".shk"}, "")
+	if shk {
+		name := runNum + ".shk"
+		shkFilePath := filepath.Join(dir, name)
+		err := errorIfNotExists(AppFs, shkFilePath, "--no-shk-file")
+		if err != nil {
+			return ModelOutput{}, err
+		}
 		shkLines, err := utils.ReadLines(shkFilePath)
 		if err != nil {
-			if os.IsNotExist(err) {
-				log.Error("no shrinkage file exists at: " + shkFilePath)
-			} else {
-				panic(err)
-			}
+			return ModelOutput{}, err
 		}
 		results.ShrinkageDetails = ParseShkData(ParseShkLines(shkLines), etaCount, epsCount)
 	}
 
 	setMissingValuesToDefault(&results, etaCount, epsCount)
-	return results
+	return results, nil
+}
+
+func errorIfNotExists(fs afero.Fs, path string, sFlag string) error {
+	exists, err := utils.Exists(path, fs)
+	if err != nil {
+		panic(fmt.Sprintf("unknown error checking file existence %s\n", err))
+	}
+	if !exists {
+		suppressionFlagMsg := "\n"
+		if sFlag != "" {
+			suppressionFlagMsg = fmt.Sprintf("\nyou can suppress bbi searching for the file using %s\n", sFlag)
+		}
+		return errors.New(fmt.Sprintf("No file present at %s%s ", path, suppressionFlagMsg))
+	}
+	return nil
 }

--- a/parsers/nmparser/get_model_output.go
+++ b/parsers/nmparser/get_model_output.go
@@ -61,13 +61,13 @@ func GetModelOutput(lstPath string, ext ModelOutputFile, grd bool, cov bool, cor
 	if err != nil {
 		// this is set to trace as don't want it to log normally as could screw up json output that
 		// requests results from this such as summary --json
-		log.Trace("error reading cpu file: %v", err)
+		log.Trace("error reading cpu file: ", err)
 	} else {
 		results.RunDetails.OutputFilesUsed = append(results.RunDetails.OutputFilesUsed, filepath.Base(cpuFilePath))
 		cpuTime, err := strconv.ParseFloat(strings.TrimSpace(cpuLines[0]), 64)
 		if err != nil {
 			// this is set to trace as don't want it to log normally as could screw up json output that
-			log.Trace("error parsing cpu time: %v", err)
+			log.Trace("error parsing cpu time: ", err)
 			results.RunDetails.CpuTime = DefaultFloat64
 		}
 		results.RunDetails.CpuTime = cpuTime

--- a/parsers/nmparser/parse_lst_file.go
+++ b/parsers/nmparser/parse_lst_file.go
@@ -328,7 +328,7 @@ func getGradientLine(lines []string, start int) string {
 }
 
 // ParseLstEstimationFile parses the lst file
-func ParseLstEstimationFile(lines []string) ModelOutput {
+func ParseLstEstimationFile(lines []string) SummaryOutput {
 	ofvDetails := NewOfvDetails()
 	runHeuristics := NewRunHeuristics()
 	var finalParameterEstimatesIndex int
@@ -418,7 +418,7 @@ func ParseLstEstimationFile(lines []string) ModelOutput {
 	// 	parameterNames = ParseParameterNames(lines[startThetaIndex:endSigmaIndex])
 	// }
 	// TODO re-replace parameter data from lst
-	result := ModelOutput{
+	result := SummaryOutput{
 		RunHeuristics: runHeuristics,
 		RunDetails:    ParseRunDetails(lines),
 		ParametersData: []ParametersData{

--- a/parsers/nmparser/parse_lst_file.go
+++ b/parsers/nmparser/parse_lst_file.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"github.com/metrumresearchgroup/babylon/utils"
 	"math"
 	"sort"
 	"strconv"
@@ -45,83 +46,6 @@ func parseFloats(line, name string) []float64 {
 		floats = append(floats, fvalue)
 	}
 	return floats
-}
-
-func parseOFV(line string, ofvDetails OfvDetails) OfvDetails {
-	if strings.Contains(line, "#OBJV:") {
-		result := strings.Replace(line, "*", "", -1)
-		ofvDetails.OFVNoConstant, _ = strconv.ParseFloat(
-			strings.TrimSpace(strings.Replace(result, "#OBJV:", "", -1)),
-			64)
-	} else if strings.Contains(line, "CONSTANT TO OBJECTIVE FUNCTION") {
-		ofvDetails.OFV, _ = strconv.ParseFloat(
-			strings.TrimSpace(strings.Replace(line, "N*LOG(2PI) CONSTANT TO OBJECTIVE FUNCTION:", "", -1)),
-			64)
-	} else if strings.Contains(line, "OBJECTIVE FUNCTION VALUE WITHOUT CONSTANT") {
-		ofvDetails.OFVNoConstant, _ = strconv.ParseFloat(
-			strings.TrimSpace(strings.Replace(line, "OBJECTIVE FUNCTION VALUE WITHOUT CONSTANT:", "", -1)),
-			64)
-	} else if strings.Contains(line, "OBJECTIVE FUNCTION VALUE WITH CONSTANT") {
-		ofvDetails.OFVWithConstant, _ = strconv.ParseFloat(
-			strings.TrimSpace(strings.Replace(line, "OBJECTIVE FUNCTION VALUE WITH CONSTANT:", "", -1)),
-			64)
-	}
-	return ofvDetails
-}
-
-func getConditionNumber(lines []string, start int) float64 {
-
-	// go until line of ints
-	for i, line := range lines[start:] {
-		sub := strings.TrimSpace(line)
-		if len(sub) > 0 {
-			vals := strings.Fields(sub)
-			if len(vals) > 1 {
-				one, err := strconv.Atoi(vals[0])
-				if err == nil && one == 1 {
-					two, err := strconv.Atoi(vals[1])
-					if err == nil && two == 2 {
-						start = start + i
-						break
-					}
-				}
-			}
-		}
-	}
-
-	// go until blank line
-	for i, line := range lines[start:] {
-		sub := strings.TrimSpace(line)
-		if len(sub) == 0 {
-			start = start + i + 1
-			break
-		}
-	}
-
-	// go until another blank line and build eigenvalues vector
-	var eigenvalues []float64
-	for i, line := range lines[start:] {
-		for _, s := range strings.Fields(line) {
-			eigenvalue, err := strconv.ParseFloat(s, 64)
-			if err == nil {
-				eigenvalues = append(eigenvalues, eigenvalue)
-			}
-		}
-
-		sub := strings.TrimSpace(line)
-		if len(sub) == 0 {
-			start = start + i + 1
-			break
-		}
-	}
-
-	ratio := 1.0 // If only 1 eigenvalue, the Condition Number is 1.0
-	if len(eigenvalues) >= 2 {
-		sort.Float64s(eigenvalues)
-		ratio = eigenvalues[len(eigenvalues)-1] / eigenvalues[0]
-	}
-
-	return ratio
 }
 
 func getMatrixData(lines []string, start int) MatrixData {
@@ -329,15 +253,15 @@ func getGradientLine(lines []string, start int) string {
 
 // ParseLstEstimationFile parses the lst file
 func ParseLstEstimationFile(lines []string) SummaryOutput {
-	ofvDetails := NewOfvDetails()
 	runHeuristics := NewRunHeuristics()
+	var allOfvDetails []OfvDetails
+	var allCondDetails []ConditionNumDetails
 	var finalParameterEstimatesIndex int
 	var standardErrorEstimateIndex int
 	var covarianceMatrixEstimateIndex int
 	var startThetaIndex int
 	var endSigmaIndex int
 	var gradientLines []string
-	var conditionNumber float64
 
 	for i, line := range lines {
 		switch {
@@ -351,14 +275,19 @@ func ParseLstEstimationFile(lines []string) SummaryOutput {
 			}
 		case strings.Contains(line, "$EST") && endSigmaIndex == 0:
 			endSigmaIndex = i
+		case strings.Contains(line, "#METH"):
+			// starting new estimation method, make new details objects
+			method := strings.TrimSpace(strings.Replace(line, "#METH:", "", -1))
+			allOfvDetails = append(allOfvDetails, NewOfvDetails(method))
+			allCondDetails = append(allCondDetails, NewConditionNumDetails(method))
 		case strings.Contains(line, "#OBJV"):
-			ofvDetails = parseOFV(line, ofvDetails)
+			allOfvDetails = parseOFV(line, allOfvDetails)
 		case strings.Contains(line, "CONSTANT TO OBJECTIVE FUNCTION"):
-			ofvDetails = parseOFV(line, ofvDetails)
+			allOfvDetails = parseOFV(line, allOfvDetails)
 		case strings.Contains(line, "OBJECTIVE FUNCTION VALUE WITHOUT CONSTANT"):
-			ofvDetails = parseOFV(line, ofvDetails)
+			allOfvDetails = parseOFV(line, allOfvDetails)
 		case strings.Contains(line, "OBJECTIVE FUNCTION VALUE WITH CONSTANT"):
-			ofvDetails = parseOFV(line, ofvDetails)
+			allOfvDetails = parseOFV(line, allOfvDetails)
 		case strings.Contains(line, "FINAL PARAMETER ESTIMATE"):
 			// want to go 3 more lines to get into text not labelled block
 			finalParameterEstimatesIndex = i + 3
@@ -381,17 +310,22 @@ func ParseLstEstimationFile(lines []string) SummaryOutput {
 		case strings.Contains(line, "COVARIANCE STEP ABORTED"):
 			runHeuristics.CovarianceStepAborted = true
 		case strings.Contains(line, "EIGENVALUES OF COR MATRIX OF ESTIMATE"):
-			conditionNumber = getConditionNumber(lines, i)
-			// TODO: get largeNumberLimit from config
-			// or derive. something like (number of parameters) * 10
-			largeNumberLimit := 1000.0
-			runHeuristics.LargeConditionNumber = conditionNumber > largeNumberLimit
+			allCondDetails = parseConditionNum(lines, i, allCondDetails)
 		default:
 			continue
 		}
 	}
 
 	runHeuristics.HasFinalZeroGradient = parseGradient(gradientLines)
+
+	// TODO: get largeNumberLimit from config
+	// or derive. something like (number of parameters) * 10
+	largeNumberLimit := 1000.0
+	cb := make([]bool, len(allCondDetails))
+	for i, cn := range(allCondDetails) {
+		cb[i] = cn.ConditionNumber > largeNumberLimit
+	}
+	runHeuristics.LargeConditionNumber = utils.AnyTrue(cb)
 
 	var finalParameterEst ParametersResult
 	var finalParameterStdErr ParametersResult
@@ -429,9 +363,105 @@ func ParseLstEstimationFile(lines []string) SummaryOutput {
 		},
 		ParameterNames: NewDefaultParameterNames(len(finalParameterEst.Theta), len(finalParameterEst.Omega), len(finalParameterEst.Sigma)),
 
-		OFV: ofvDetails,
+		OFV: allOfvDetails,
 
-		ConditionNumber: conditionNumber,
+		ConditionNumber: allCondDetails,
 	}
 	return result
+}
+
+func parseOFV(line string, allOfvDetails []OfvDetails) []OfvDetails {
+	// always modify the most recently created OfvDetails
+	ofvDetails := &allOfvDetails[len(allOfvDetails) - 1]
+
+	if strings.Contains(line, "#OBJV:") {
+		result := strings.Replace(line, "*", "", -1)
+		ofvDetails.OFVNoConstant, _ = strconv.ParseFloat(
+			strings.TrimSpace(strings.Replace(result, "#OBJV:", "", -1)),
+			64)
+	} else if strings.Contains(line, "CONSTANT TO OBJECTIVE FUNCTION") {
+		constantString := strings.TrimSpace(strings.Replace(line, "CONSTANT TO OBJECTIVE FUNCTION:", "", -1))
+		constantPrefixes := []string{
+			"N*LOG(2PI)",
+			"NIND*NETA*LOG(2PI)",
+			"PRIOR",
+		}
+		for _, cp := range(constantPrefixes) {
+			constantString = strings.TrimSpace(strings.Replace(constantString, cp, "", -1))
+		}
+		ofvDetails.ConstantToOFV, _ = strconv.ParseFloat(constantString, 64)
+	} else if strings.Contains(line, "OBJECTIVE FUNCTION VALUE WITHOUT CONSTANT") {
+		ofvDetails.OFVNoConstant, _ = strconv.ParseFloat(
+			strings.TrimSpace(strings.Replace(line, "OBJECTIVE FUNCTION VALUE WITHOUT CONSTANT:", "", -1)),
+			64)
+	} else if strings.Contains(line, "OBJECTIVE FUNCTION VALUE WITH CONSTANT") {
+		ofvDetails.OFVWithConstant, _ = strconv.ParseFloat(
+			strings.TrimSpace(strings.Replace(line, "OBJECTIVE FUNCTION VALUE WITH CONSTANT:", "", -1)),
+			64)
+	}
+	return allOfvDetails
+}
+
+func parseConditionNum(lines []string, start int, allCondDetails []ConditionNumDetails, ) []ConditionNumDetails {
+	// always modify the most recently created ConditionNumDetails
+	condDetails := &allCondDetails[len(allCondDetails) - 1]
+
+	condDetails.ConditionNumber = calculateConditionNumber(lines, start)
+
+	return allCondDetails
+}
+
+func calculateConditionNumber(lines []string, start int) float64 {
+
+	// go until line of ints
+	for i, line := range lines[start:] {
+		sub := strings.TrimSpace(line)
+		if len(sub) > 0 {
+			vals := strings.Fields(sub)
+			if len(vals) > 1 {
+				one, err := strconv.Atoi(vals[0])
+				if err == nil && one == 1 {
+					two, err := strconv.Atoi(vals[1])
+					if err == nil && two == 2 {
+						start = start + i
+						break
+					}
+				}
+			}
+		}
+	}
+
+	// go until blank line
+	for i, line := range lines[start:] {
+		sub := strings.TrimSpace(line)
+		if len(sub) == 0 {
+			start = start + i + 1
+			break
+		}
+	}
+
+	// go until another blank line and build eigenvalues vector
+	var eigenvalues []float64
+	for i, line := range lines[start:] {
+		for _, s := range strings.Fields(line) {
+			eigenvalue, err := strconv.ParseFloat(s, 64)
+			if err == nil {
+				eigenvalues = append(eigenvalues, eigenvalue)
+			}
+		}
+
+		sub := strings.TrimSpace(line)
+		if len(sub) == 0 {
+			start = start + i + 1
+			break
+		}
+	}
+
+	ratio := 1.0 // If only 1 eigenvalue, the Condition Number is 1.0
+	if len(eigenvalues) >= 2 {
+		sort.Float64s(eigenvalues)
+		ratio = eigenvalues[len(eigenvalues)-1] / eigenvalues[0]
+	}
+
+	return ratio
 }

--- a/parsers/nmparser/parse_lst_file_test.go
+++ b/parsers/nmparser/parse_lst_file_test.go
@@ -256,7 +256,7 @@ func TestConditionNumber(t *testing.T) {
 
 	for _, tt := range tests {
 
-		conditionNumber := getConditionNumber(tt.lines, tt.n)
+		conditionNumber := calculateConditionNumber(tt.lines, tt.n)
 		// compare to three decimal places
 		assert.Equal(t, tt.conditionNumber, math.Round(conditionNumber*1000)/1000, "Fail :"+tt.context)
 	}

--- a/parsers/nmparser/parse_lst_file_test.go
+++ b/parsers/nmparser/parse_lst_file_test.go
@@ -173,10 +173,11 @@ func TestParseGradient(t *testing.T) {
 	}
 }
 
-func TestSetLargeConditionNumber(t *testing.T) {
+func TestConditionNumber(t *testing.T) {
 	var tests = []struct {
 		lines                []string
 		n                    int
+		conditionNumber      float64
 		largeConditionNumber bool
 		context              string
 	}{
@@ -197,7 +198,7 @@ func TestSetLargeConditionNumber(t *testing.T) {
 				" Elapsed finaloutput time in seconds:     0.16                                                                           ",
 			},
 			n:                    3,
-			largeConditionNumber: false,
+			conditionNumber:      10.316,
 			context:              "not large",
 		},
 		{
@@ -217,7 +218,7 @@ func TestSetLargeConditionNumber(t *testing.T) {
 				" Elapsed finaloutput time in seconds:     0.16                                                                           ",
 			},
 			n:                    3,
-			largeConditionNumber: true,
+			conditionNumber:      10316.206,
 			context:              "large",
 		},
 		// {
@@ -226,12 +227,38 @@ func TestSetLargeConditionNumber(t *testing.T) {
 		// 	largeConditionNumber: Undefined,
 		// 	context:              "not set",
 		// },
+
+		{
+			lines: []string{
+				"                                                                                                                                   ",
+				" ************************************************************************************************************************          ",
+				" ********************                                                                                ********************          ",
+				" ********************               OBJECTIVE FUNCTION EVALUATION BY IMPORTANCE SAMPLING             ********************          ",
+				" ********************                   EIGENVALUES OF COR MATRIX OF ESTIMATE (RSR)                  ********************          ",
+				" ********************                                                                                ********************          ",
+				" ************************************************************************************************************************          ",
+				"                                                                                                                                   ",
+				"                                                                                                                                   ",
+				"             1         2         3         4         5         6         7         8         9        10        11        12       ",
+				"             13        14        15        16        17        18        19                                                        ",
+				"                                                                                                                                   ",
+				"         7.19E-11  1.01E-08  1.87E-07  9.06E-07  1.63E-06  3.50E-06  2.87E-05  3.76E-04  1.14E-03  1.47E-02  1.95E-02  2.31E-02    ",
+				"          3.21E-02  7.21E-02  3.80E-01  5.27E-01  1.11E+00  1.19E+00  1.56E+01                                                     ",
+				"                                                                                                                                   ",
+				"                                                                                                                                   ",
+				"Elapsed postprocess time in seconds:     7.30                                                                                      ",
+			},
+			n:                    5,
+			conditionNumber:      2.16968011126565e+11,
+			context:              "two lines",
+		},
 	}
 
 	for _, tt := range tests {
 
-		largeConditionNumber := getLargeConditionNumberStatus(tt.lines, tt.n, 1000.0)
-		assert.Equal(t, tt.largeConditionNumber, largeConditionNumber, "Fail :"+tt.context)
+		conditionNumber := getConditionNumber(tt.lines, tt.n)
+		// compare to three decimal places
+		assert.Equal(t, tt.conditionNumber, math.Round(conditionNumber*1000)/1000, "Fail :"+tt.context)
 	}
 }
 

--- a/parsers/nmparser/parse_run_details.go
+++ b/parsers/nmparser/parse_run_details.go
@@ -61,6 +61,8 @@ func ParseRunDetails(lines []string) RunDetails {
 			runDetails.CovarianceTime = parseFinalTime(line)
 		case strings.Contains(line, "Elapsed postprocess time in seconds:"):
 			runDetails.CovarianceTime = parseFinalTime(line)
+		case strings.Contains(line, " #CPUT: Total CPU Time in Seconds,"):
+			runDetails.CpuTime, _ = strconv.ParseFloat(replaceTrim(line, " #CPUT: Total CPU Time in Seconds,"), 64)
 		case strings.Contains(line, "Started"):
 			runDetails.RunStart = replaceTrim(line, "Started")
 		case strings.Contains(line, "Finished"):

--- a/parsers/nmparser/parse_run_details_test.go
+++ b/parsers/nmparser/parse_run_details_test.go
@@ -37,6 +37,7 @@ var RunDetails01Results = RunDetails{
 	"Tue Dec 17 18:11:32 2013",
 	6.84,
 	3.34,
+	10.5, // this is made up, not for an actual run output
 	352,
 	3.4,
 	"3.mod, double inital estimates",
@@ -46,7 +47,7 @@ var RunDetails01Results = RunDetails{
 	50,
 	442,
 	492,
-	"-999999999",
+	[]string{"-999999999"},
 	[]string{""},
 }
 
@@ -58,6 +59,7 @@ var RunDetails02Results = RunDetails{
 	"Fri Jul 12 09:27:20 EDT 2019",
 	0.68,
 	0.02,
+	10.5, // this is made up, not for an actual run output
 	178,
 	3.1,
 	"1 model, 1 comp",
@@ -67,7 +69,7 @@ var RunDetails02Results = RunDetails{
 	50,
 	442,
 	492,
-	"",
+	[]string{""},
 	[]string{""},
 }
 

--- a/parsers/nmparser/set_missing_values_to_default.go
+++ b/parsers/nmparser/set_missing_values_to_default.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-func setMissingValuesToDefault(results *ModelOutput, etaCount, epsCount int) {
+func setMissingValuesToDefault(results *SummaryOutput, etaCount, epsCount int) {
 	// method name
 	for i := range results.ParametersData {
 		if len(results.ParametersData[i].Method) == 0 {

--- a/parsers/nmparser/set_missing_values_to_default_test.go
+++ b/parsers/nmparser/set_missing_values_to_default_test.go
@@ -9,19 +9,19 @@ import (
 
 func TestSetMissingValuesToDefaultParameterDataMethod(t *testing.T) {
 	var tests = []struct {
-		modelOutput ModelOutput
+		modelOutput SummaryOutput
 		etaCount    int
 		epsCount    int
 		expected    string
 	}{
 		{
-			modelOutput: ModelOutput{
+			modelOutput: SummaryOutput{
 				ParametersData: []ParametersData{ParametersData{}},
 			},
 			expected: "METHOD NOT DETECTED",
 		},
 		{
-			modelOutput: ModelOutput{
+			modelOutput: SummaryOutput{
 				ParametersData: []ParametersData{ParametersData{
 					Method: "Test Method",
 				}},
@@ -37,14 +37,14 @@ func TestSetMissingValuesToDefaultParameterDataMethod(t *testing.T) {
 
 func TestSetMissingValuesToDefaultParameterDataStdErrDimension(t *testing.T) {
 	var tests = []struct {
-		modelOutput ModelOutput
+		modelOutput SummaryOutput
 		etaCount    int
 		epsCount    int
 		expected    int
 		context     string
 	}{
 		{
-			modelOutput: ModelOutput{
+			modelOutput: SummaryOutput{
 				ParametersData: []ParametersData{ParametersData{
 					Estimates: ParametersResult{
 						Theta: []float64{1, 2, 4},
@@ -65,14 +65,14 @@ func TestSetMissingValuesToDefaultParameterDataStdErrDimension(t *testing.T) {
 
 func TestSetMissingValuesToDefaultParameterDataRESDDimension(t *testing.T) {
 	var tests = []struct {
-		modelOutput ModelOutput
+		modelOutput SummaryOutput
 		etaCount    int
 		epsCount    int
 		expected    int
 		context     string
 	}{
 		{
-			modelOutput: ModelOutput{
+			modelOutput: SummaryOutput{
 				ParametersData: []ParametersData{ParametersData{
 					Estimates: ParametersResult{
 						Omega: []float64{1, 2, 4},
@@ -93,14 +93,14 @@ func TestSetMissingValuesToDefaultParameterDataRESDDimension(t *testing.T) {
 
 func TestSetMissingValuesToDefaultParameterDataValues(t *testing.T) {
 	var tests = []struct {
-		modelOutput ModelOutput
+		modelOutput SummaryOutput
 		etaCount    int
 		epsCount    int
 		expected    int
 		context     string
 	}{
 		{
-			modelOutput: ModelOutput{
+			modelOutput: SummaryOutput{
 				ParametersData: []ParametersData{ParametersData{
 					Estimates: ParametersResult{
 						Omega: []float64{1, 2, 4},
@@ -127,14 +127,14 @@ func TestSetMissingValuesToDefaultParameterDataValues(t *testing.T) {
 
 func TestSetMissingValuesToDefaultParameterNameValues(t *testing.T) {
 	var tests = []struct {
-		modelOutput ModelOutput
+		modelOutput SummaryOutput
 		etaCount    int
 		epsCount    int
 		expected    int
 		context     string
 	}{
 		{
-			modelOutput: ModelOutput{
+			modelOutput: SummaryOutput{
 				ParametersData: []ParametersData{ParametersData{
 					Estimates: ParametersResult{
 						Theta: []float64{1, 2, 4},
@@ -156,14 +156,14 @@ func TestSetMissingValuesToDefaultParameterNameValues(t *testing.T) {
 
 func TestSetMissingValuesToDefaultShrinkageEta(t *testing.T) {
 	var tests = []struct {
-		modelOutput ModelOutput
+		modelOutput SummaryOutput
 		etaCount    int
 		epsCount    int
 		expected    int
 		context     string
 	}{
 		{
-			modelOutput: ModelOutput{
+			modelOutput: SummaryOutput{
 				ParametersData: []ParametersData{ParametersData{
 					Estimates: ParametersResult{},
 				}},
@@ -182,14 +182,14 @@ func TestSetMissingValuesToDefaultShrinkageEta(t *testing.T) {
 
 func TestSetMissingValuesToDefaultShrinkageEps(t *testing.T) {
 	var tests = []struct {
-		modelOutput ModelOutput
+		modelOutput SummaryOutput
 		etaCount    int
 		epsCount    int
 		expected    int
 		context     string
 	}{
 		{
-			modelOutput: ModelOutput{
+			modelOutput: SummaryOutput{
 				ParametersData: []ParametersData{ParametersData{
 					Estimates: ParametersResult{},
 				}},

--- a/parsers/nmparser/structs.go
+++ b/parsers/nmparser/structs.go
@@ -9,7 +9,7 @@ type FlatArray struct {
 	Dim    int       `json:"dim,omitempty"`
 }
 
-// ParameterNames containst the names of model parameters
+// ParameterNames contains the names of model parameters
 type ParameterNames struct {
 	Theta []string `json:"theta,omitempty"`
 	Omega []string `json:"omega,omitempty"`
@@ -62,6 +62,7 @@ type RunDetails struct {
 	RunEnd              string   `json:"run_end,omitempty"`
 	EstimationTime      float64  `json:"estimation_time,omitempty"`
 	CovarianceTime      float64  `json:"covariance_time,omitempty"`
+	CpuTime             float64  `json:"cpu_time,omitempty"`
 	FunctionEvaluations int64    `json:"function_evaluations,omitempty"`
 	SignificantDigits   float64  `json:"significant_digits,omitempty"`
 	ProblemText         string   `json:"problem_text,omitempty"`
@@ -71,7 +72,7 @@ type RunDetails struct {
 	NumberOfPatients    int64    `json:"number_of_patients,omitempty"`
 	NumberOfObs         int64    `json:"number_of_obs,omitempty"`
 	NumberOfDataRecords int64    `json:"number_of_data_records,omitempty"`
-	OutputTable         string   `json:"output_table,omitempty"`
+	OutputTables         []string   `json:"output_tables,omitempty"`
 	OutputFilesUsed     []string `json:"output_files_used,omitempty"`
 }
 
@@ -187,7 +188,7 @@ func NewRunDetails() RunDetails {
 		NumberOfPatients:    DefaultInt64,
 		NumberOfObs:         DefaultInt64,
 		NumberOfDataRecords: DefaultInt64,
-		OutputTable:         DefaultString,
+		OutputTables:         []string{},
 		OutputFilesUsed:     []string{},
 	}
 	return runDetails

--- a/parsers/nmparser/structs.go
+++ b/parsers/nmparser/structs.go
@@ -54,7 +54,7 @@ type RunHeuristics struct {
 	HasFinalZeroGradient   bool `json:"has_final_zero_gradient"`
 	MinimizationTerminated bool `json:"minimization_terminated"`
 	EtaPvalSignificant     bool `json:"eta_pval_significant"`
-	PRDERR				   bool `json:"prederr"`
+	PRDERR				   bool `json:"prderr"`
 }
 
 // RunDetails contains key information about logistics of the model run

--- a/parsers/nmparser/structs.go
+++ b/parsers/nmparser/structs.go
@@ -128,8 +128,8 @@ type OfvDetails struct {
 	OFVWithConstant float64 `json:"ofv_with_constant,omitempty"`
 }
 
-// ModelOutput is the output struct from a lst file
-type ModelOutput struct {
+// SummaryOutput is the output struct from a lst file
+type SummaryOutput struct {
 	RunDetails       RunDetails           `json:"run_details,omitempty"`
 	RunHeuristics    RunHeuristics        `json:"run_heuristics,omitempty"`
 	ParametersData   []ParametersData     `json:"parameters_data,omitempty"`
@@ -137,6 +137,10 @@ type ModelOutput struct {
 	OFV              OfvDetails           `json:"ofv,omitempty"`
 	ConditionNumber  float64              `json:"condition_number,omitempty"`
 	ShrinkageDetails [][]ShrinkageDetails `json:"shrinkage_details,omitempty"`
+}
+
+// CovCorOutput is the output from parsing the .cov and .cor file
+type CovCorOutput struct {
 	CovarianceTheta  []FlatArray          `json:"covariance_theta,omitempty"`
 	CorrelationTheta []FlatArray          `json:"correlation_theta,omitempty"`
 }

--- a/parsers/nmparser/structs.go
+++ b/parsers/nmparser/structs.go
@@ -53,6 +53,8 @@ type RunHeuristics struct {
 	HessianReset           bool `json:"hessian_reset"`
 	HasFinalZeroGradient   bool `json:"has_final_zero_gradient"`
 	MinimizationTerminated bool `json:"minimization_terminated"`
+	EtaPvalSignificant     bool `json:"eta_pval_significant"`
+	PRDERR				   bool `json:"prederr"`
 }
 
 // RunDetails contains key information about logistics of the model run
@@ -123,20 +125,27 @@ type CovarianceStep struct {
 
 // OfvDetails ...
 type OfvDetails struct {
-	OFV             float64 `json:"ofv,omitempty"`
+	EstMethod		string  `json:"method,omitempty"`
 	OFVNoConstant   float64 `json:"ofv_no_constant,omitempty"`
+	ConstantToOFV   float64 `json:"constant_to_ofv,omitempty"`
 	OFVWithConstant float64 `json:"ofv_with_constant,omitempty"`
+}
+
+// OfvDetails ...
+type ConditionNumDetails struct {
+	EstMethod		 string  `json:"method,omitempty"`
+	ConditionNumber  float64 `json:"condition_number,omitempty"`
 }
 
 // SummaryOutput is the output struct from a lst file
 type SummaryOutput struct {
-	RunDetails       RunDetails           `json:"run_details,omitempty"`
-	RunHeuristics    RunHeuristics        `json:"run_heuristics,omitempty"`
-	ParametersData   []ParametersData     `json:"parameters_data,omitempty"`
-	ParameterNames   ParameterNames       `json:"parameter_names,omitempty"`
-	OFV              OfvDetails           `json:"ofv,omitempty"`
-	ConditionNumber  float64              `json:"condition_number,omitempty"`
-	ShrinkageDetails [][]ShrinkageDetails `json:"shrinkage_details,omitempty"`
+	RunDetails       RunDetails             `json:"run_details,omitempty"`
+	RunHeuristics    RunHeuristics          `json:"run_heuristics,omitempty"`
+	ParametersData   []ParametersData       `json:"parameters_data,omitempty"`
+	ParameterNames   ParameterNames         `json:"parameter_names,omitempty"`
+	OFV              []OfvDetails           `json:"ofv,omitempty"`
+	ConditionNumber  []ConditionNumDetails  `json:"condition_number,omitempty"`
+	ShrinkageDetails [][]ShrinkageDetails   `json:"shrinkage_details,omitempty"`
 }
 
 // CovCorOutput is the output from parsing the .cov and .cor file
@@ -200,14 +209,26 @@ func NewRunDetails() RunDetails {
 }
 
 // NewOfvDetails ...
-func NewOfvDetails() OfvDetails {
+func NewOfvDetails(method string) OfvDetails {
+
 	ofvDetails := OfvDetails{
-		OFV:             DefaultFloat64,
+		EstMethod: 		 method,
 		OFVNoConstant:   DefaultFloat64,
+		ConstantToOFV:   DefaultFloat64,
 		OFVWithConstant: DefaultFloat64,
 	}
 	return ofvDetails
 }
+
+func NewConditionNumDetails(method string) ConditionNumDetails {
+
+	conditionNumDetails := ConditionNumDetails{
+		EstMethod: 		 method,
+		ConditionNumber: DefaultFloat64,
+	}
+	return conditionNumDetails
+}
+
 
 // NewRunHeuristics provides a new run heuristics struct
 // at the moment it just returns all defaults, however

--- a/parsers/nmparser/structs.go
+++ b/parsers/nmparser/structs.go
@@ -135,6 +135,7 @@ type ModelOutput struct {
 	ParametersData   []ParametersData     `json:"parameters_data,omitempty"`
 	ParameterNames   ParameterNames       `json:"parameter_names,omitempty"`
 	OFV              OfvDetails           `json:"ofv,omitempty"`
+	ConditionNumber  float64              `json:"condition_number,omitempty"`
 	ShrinkageDetails [][]ShrinkageDetails `json:"shrinkage_details,omitempty"`
 	CovarianceTheta  []FlatArray          `json:"covariance_theta,omitempty"`
 	CorrelationTheta []FlatArray          `json:"correlation_theta,omitempty"`

--- a/parsers/nmparser/summary.go
+++ b/parsers/nmparser/summary.go
@@ -18,7 +18,8 @@ func (results SummaryOutput) Summary() bool {
 	thetaTable.SetHeader([]string{"Theta", "Name", "Estimate", "StdErr (RSE)"})
 	// required for color, prevents newline in row
 	thetaTable.SetAutoWrapText(false)
-	isBayesian := results.RunDetails.EstimationMethods[0] == "MCMC Bayesian Analysis"
+	//isBayesian := CheckIfBayesian(results)
+	shk := results.ShrinkageDetails != nil
 	finalEstimationMethodIndex := len(results.ParametersData) - 1
 	for i := range results.ParametersData[finalEstimationMethodIndex].Estimates.Theta {
 		numResult := results.ParametersData[finalEstimationMethodIndex].Estimates.Theta[i]
@@ -51,7 +52,7 @@ func (results SummaryOutput) Summary() bool {
 	omegaTable.SetAlignment(tablewriter.ALIGN_LEFT)
 	omegaTable.SetColWidth(100)
 	omegaHeaders := []string{"Omega", "Eta", "Estimate"}
-	if !isBayesian {
+	if shk {
 		// bayesian methods have no concept of shrinkage
 		nSubPopsForMixtureModels := len(results.ShrinkageDetails[len(results.RunDetails.EstimationMethods)-1])
 		if nSubPopsForMixtureModels > 1 {
@@ -78,7 +79,7 @@ func (results SummaryOutput) Summary() bool {
 		val := results.ParametersData[finalEstimationMethodIndex].Estimates.Omega[n]
 		if isDiag {
 			etaName = fmt.Sprintf("ETA%v", diagIndex)
-			if !isBayesian {
+			if shk {
 				for sp := range results.ShrinkageDetails[methodIndex] {
 					if len(results.ShrinkageDetails[methodIndex]) > 0 {
 						// get the data for the last method

--- a/parsers/nmparser/summary.go
+++ b/parsers/nmparser/summary.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Summary prints all results from the parsed LstData
-func (results ModelOutput) Summary() bool {
+func (results SummaryOutput) Summary() bool {
 	thetaTable := tablewriter.NewWriter(os.Stdout)
 	thetaTable.SetAlignment(tablewriter.ALIGN_LEFT)
 	thetaTable.SetColWidth(100)

--- a/parsers/nmparser/utils.go
+++ b/parsers/nmparser/utils.go
@@ -1,5 +1,7 @@
 package parser
 
+import "github.com/thoas/go-funk"
+
 // createDiagonalBlock creates a slice of ints that would form a diagonal matrix with value 1 for diagonal and 0 for off diagonal elements
 func createDiagonalBlock(num int) []int {
 	var iArr []int
@@ -13,4 +15,30 @@ func createDiagonalBlock(num int) []int {
 		}
 	}
 	return iArr
+}
+
+// Checks the final estimation method against a list of non-gradient based methods.
+// Primarily used for deciding whether to look for a .grd file to parse
+func CheckIfNotGradientBased(results SummaryOutput) bool {
+	isNotGradientBased := funk.Contains([]string{
+		"MCMC Bayesian Analysis",
+		"Stochastic Approximation Expectation-Maximization",
+		"Importance Sampling assisted by MAP Estimation",
+		"Importance Sampling",
+		"Importance Sampling (No Prior)",
+		"NUTS Bayesian Analysis",
+		"Objective Function Evaluation by Importance Sampling",
+	}, results.RunDetails.EstimationMethods[len(results.RunDetails.EstimationMethods)-1])
+
+	return isNotGradientBased
+}
+
+// Checks the final estimation method against a list of Bayesian methods.
+func CheckIfBayesian(results SummaryOutput) bool {
+	isBayesian := funk.Contains([]string{
+		"MCMC Bayesian Analysis",
+		"NUTS Bayesian Analysis",
+	}, results.RunDetails.EstimationMethods[len(results.RunDetails.EstimationMethods)-1])
+
+	return isBayesian
 }

--- a/utils/io.go
+++ b/utils/io.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -33,6 +34,14 @@ func ReadParamsAndOutputFromExt(path string) ([]string, error) {
 		default:
 			continue
 		}
+	}
+
+	// if file was empty prompt about renamed .ext file
+	if lines == nil {
+		emptyFileMsg := fmt.Sprintf("A file exists at %s but it is empty.\n", path)
+		renameExtMsg := "If you sent NONMEM output to a different file you can use --ext-file=NEWFILE to specify the new file name.\n"
+		err = errors.New(emptyFileMsg+renameExtMsg)
+		return nil, err
 	}
 	return lines, nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -240,3 +240,14 @@ func ListFiles(fd []os.FileInfo) []string {
 	}
 	return files
 }
+
+// Takes a boolean slice and returns a boolean for whether
+// any elements of the slice are true
+func AnyTrue(bools []bool) bool {
+	for _, v := range bools {
+		if v {
+			return true
+		}
+	}
+	return false
+}

--- a/validation.json
+++ b/validation.json
@@ -1,5 +1,6 @@
 {
   "project" : "Babylon",
+  "release" : "v2.3.0",
   "scope" : "A next-generation modeling tool that allows for local and grid-based execution of NonMem jobs. Supports legacy functionality such as NMQual execution mode and the ability to pass raw options to NMFE. Self-bootstrapping, Babylon can evaluate your environment to locate Nonmem locations and codify them into configuration",
   "markdown" : [
     {
@@ -8,7 +9,7 @@
   ],
   "stories" : [
     {
-      "name" : "Babylon should allow users to run NonMem locally",
+      "name" : "Run NonMem jobs locally",
       "tags" : [
         "TestBabylonCompletesLocalExecution",
         "TestBabylonParallelExecution"
@@ -21,7 +22,7 @@
       ]
     },
     {
-      "name" : "Babylon should allow users to run NonMem jobs on the Grid",
+      "name" : "Run NonMem jobs on the Grid",
       "tags" : [
         "TestBabylonCompletesSGEExecution",
         "TestBabylonCompletesParallelSGEExecution"
@@ -34,7 +35,7 @@
       ]
     },
     {
-      "name" : "Babylon should notify users of issues with the data referenced in the control stream",
+      "name" : "Notify about issues with the data referenced in the control stream",
       "tags" : [
         "TestHasValidPathForCTL",
         "TestHasInvalidDataPath",
@@ -48,7 +49,7 @@
       ]
     },
     {
-      "name" : "Babylon should be able to initialize a project with minimum configs required for execution",
+      "name" : "Initialize a project with minimum configs required for execution",
       "tags" : [
         "TestInitialization"
       ],
@@ -60,7 +61,7 @@
       ]
     },
     {
-      "name" : "Babylon should allow passage of some NMFE options directly to NonMem",
+      "name" : "Pass NMFE options directly to NonMem",
       "tags" : [
         "TestNMFEOptionsEndInScript"
       ],
@@ -72,11 +73,11 @@
       ]
     },
     {
-      "name" : "Babylon should capture all configurations and render them into a file that can be stored in version control",
+      "name" : "Capture all configurations and write to a file",
       "tags" : [
         "TestBBIConfigJSONCreated"
       ],
-      "risk" : "low",
+      "risk" : "high",
       "markdown" : [
         {
           "source" : "https://raw.githubusercontent.com/metrumresearchgroup/babylontest/master/markdown/stories/store_configuration.md"
@@ -84,14 +85,44 @@
       ]
     },
     {
-      "name" : "Babylon should allow for NonMem execution via NMQual",
+      "name" : "NonMem Execution via NMQual",
       "tags" : [
         "TestNMQUALExecutionSucceeds"
+      ],
+      "risk" : "low",
+      "markdown" : [
+        {
+          "source" : "https://raw.githubusercontent.com/metrumresearchgroup/babylontest/master/markdown/stories/nmqual_execution.md"
+        }
+      ]
+    },
+    {
+      "name" : "Parse model output folder",
+      "tags" : [
+        "TestSummaryHappyPath",
+        "TestSummaryArgs",
+        "TestSummaryErrors",
+        "TestSummaryHappyPathNoExtension"
+
       ],
       "risk" : "medium",
       "markdown" : [
         {
-          "source" : "https://raw.githubusercontent.com/metrumresearchgroup/babylontest/master/markdown/stories/nmqual_execution.md"
+          "source" : "https://raw.githubusercontent.com/metrumresearchgroup/babylontest/master/markdown/stories/bbi_summary.md"
+        }
+      ]
+    },
+    {
+      "name" : "Parse .cov and .cor files",
+      "tags" : [
+        "TestCovCorHappyPath",
+        "TestCovCorErrors"
+
+      ],
+      "risk" : "low",
+      "markdown" : [
+        {
+          "source" : "https://raw.githubusercontent.com/metrumresearchgroup/babylontest/master/markdown/stories/bbi_covcor.md"
         }
       ]
     }


### PR DESCRIPTION
Release 2.3.0

Changes made in 

* https://github.com/metrumresearchgroup/babylon/pull/174
* https://github.com/metrumresearchgroup/babylon/pull/176
* https://github.com/metrumresearchgroup/babylon/pull/182

Release note below describe code changes. Also made changes to `.drone.yml` and some test files to facilitate rendering updated validation documents with [babylontest](https://github.com/metrumresearchgroup/babylontest) and [goProjectValidator](https://github.com/metrumresearchgroup/goProjectValidator).

# Release Notes (to be copied to release page)

All changes for this release only effect the `bbi nonmem summary` command and its output.

## Additions and changes

* `bbi nonmem summary` will no longer parse the `.cov` and `.cor` files
  * `summary --json` output will no longer have `covariance_theta` or `correlation_theta` elements
  * `--no-cov-file` and `--no-cor-file` flags are deprecated
* `bbi nonmem covcor` command now returns the json output that was formerly contained in the `covariance_theta` or `correlation_theta` elements. The `--json` flag is not needed for this command. It always returns json.
* The following fields were added or modified in the `bbi nonmem summary --json` output:
  * **ofv** -- Previously included the objective function value for only the last estimation method. Now includes all estimation methods.
  * **condition_number** -- The condition number. This will only be in the .lst file in certain cases (when scientists ask for it in the $COV block `PRINT=E`). There will be one for each estimation method. If any of them are large, the `large_condition_number` boolean under `run_heuristics` will be `true`.
  * **eta_pval_significant** -- Added to `run_heuristics`. `true` if any `shrinkage_details.pval` < 0.05. Will be `false` if no shrinkage file is present.
  * **PRDERR** -- Added to `run_heuristics`. Indicates whether a `PRDERR` file is present in the output directory.

## Bug fixes
* Previously, the `.shk` file was not added to the `files_used` section of the `bbi nonmem summary --json` output, even when it was used. This has been fixed.