### PR TITLE
Debugging issue Tim W found with empty parameter table

### DIFF
--- a/parsers/nmparser/diagonal_elements.go
+++ b/parsers/nmparser/diagonal_elements.go
@@ -5,16 +5,42 @@ import (
 	"math"
 )
 
+// lowerDiagonalLengthToDimension takes l which is
+// the number of total elements in the lower diagonal
+//  matrix, and calculates the dimension (aka number of
+// diagonal elements) for the matrix.
+// Additionally, this function can be used to pass
+// a specific index from the array of lower diagonal
+// elements (as l). In that case, it will return one
+// of the following:
+// * If the index is a diagonal element:
+//   * The number of that diagonal element
+//   * true
+// * If the index is not a diagonal element:
+//   * 0
+//   * false
+// For example, ther are 6 elements in the lower
+// diagonal of a 3x3 matrix, the 1st, 3rd, and 6th
+// being diagonals. Calling this function on 1-6
+// would return the following:
+// lowerDiagonalLengthToDimension(1) => 1, true
+// lowerDiagonalLengthToDimension(2) => 0, false
+// lowerDiagonalLengthToDimension(3) => 2, true
+// lowerDiagonalLengthToDimension(4) => 0, false
+// lowerDiagonalLengthToDimension(5) => 0, false
+// lowerDiagonalLengthToDimension(6) => 3, true
 func lowerDiagonalLengthToDimension(l int) (int, bool) {
-
-	// estimate the dimension
+	​
+	// calculate the dimension
 	dim := int(math.Floor(math.Sqrt(2.0 * float64(l))))
-
+	​
 	// if not equal going back the other way then it's not a diagonal
 	check := (dim * (dim + 1)) / 2
-	is_diag := l == check
-
-	return dim, is_diag
+	if l != check {
+		return 0, false
+	}
+	​
+	return dim, true
 }
 
 func IndexAndIsDiag(i int) (int, bool) {

--- a/parsers/nmparser/diagonal_elements.go
+++ b/parsers/nmparser/diagonal_elements.go
@@ -19,7 +19,7 @@ import (
 // * If the index is not a diagonal element:
 //   * 0
 //   * false
-// For example, ther are 6 elements in the lower
+// For example, there are 6 elements in the lower
 // diagonal of a 3x3 matrix, the 1st, 3rd, and 6th
 // being diagonals. Calling this function on 1-6
 // would return the following:
@@ -30,16 +30,16 @@ import (
 // lowerDiagonalLengthToDimension(5) => 0, false
 // lowerDiagonalLengthToDimension(6) => 3, true
 func lowerDiagonalLengthToDimension(l int) (int, bool) {
-	​
+
 	// calculate the dimension
 	dim := int(math.Floor(math.Sqrt(2.0 * float64(l))))
-	​
+
 	// if not equal going back the other way then it's not a diagonal
 	check := (dim * (dim + 1)) / 2
 	if l != check {
 		return 0, false
 	}
-	​
+
 	return dim, true
 }
 

--- a/parsers/nmparser/utils.go
+++ b/parsers/nmparser/utils.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"github.com/metrumresearchgroup/babylon/utils"
 	"strings"
 )
 
@@ -31,12 +30,13 @@ func CheckIfNotGradientBased(results SummaryOutput) bool {
 		"Importance Sampling",
 	}
 
-	checkMethods := make([]bool, 0)
 	for _, m := range notGradientMethods {
-		checkMethods = append(checkMethods, strings.Contains(finalMethod, m))
+		if strings.Contains(finalMethod, m) {
+			return true
+		}
 	}
 
-	return utils.AnyTrue(checkMethods)
+	return false
 }
 
 // Checks the final estimation method for the string "Bayesian Analysis"

--- a/parsers/nmparser/utils.go
+++ b/parsers/nmparser/utils.go
@@ -1,6 +1,9 @@
 package parser
 
-import "github.com/thoas/go-funk"
+import (
+	"github.com/metrumresearchgroup/babylon/utils"
+	"strings"
+)
 
 // createDiagonalBlock creates a slice of ints that would form a diagonal matrix with value 1 for diagonal and 0 for off diagonal elements
 func createDiagonalBlock(num int) []int {
@@ -20,25 +23,29 @@ func createDiagonalBlock(num int) []int {
 // Checks the final estimation method against a list of non-gradient based methods.
 // Primarily used for deciding whether to look for a .grd file to parse
 func CheckIfNotGradientBased(results SummaryOutput) bool {
-	isNotGradientBased := funk.Contains([]string{
-		"MCMC Bayesian Analysis",
-		"Stochastic Approximation Expectation-Maximization",
-		"Importance Sampling assisted by MAP Estimation",
-		"Importance Sampling",
-		"Importance Sampling (No Prior)",
-		"NUTS Bayesian Analysis",
-		"Objective Function Evaluation by Importance Sampling",
-	}, results.RunDetails.EstimationMethods[len(results.RunDetails.EstimationMethods)-1])
+		finalMethod := results.RunDetails.EstimationMethods[len(results.RunDetails.EstimationMethods)-1]
 
-	return isNotGradientBased
+		notGradientMethods := []string{
+		"Bayesian Analysis",
+		"Stochastic Approximation Expectation-Maximization",
+		"Importance Sampling",
+	}
+
+	checkMethods := make([]bool, 0)
+	for _, m := range notGradientMethods {
+		checkMethods = append(checkMethods, strings.Contains(finalMethod, m))
+	}
+
+	return utils.AnyTrue(checkMethods)
 }
 
-// Checks the final estimation method against a list of Bayesian methods.
+// Checks the final estimation method for the string "Bayesian Analysis"
+// which is present in all Bayesian methods (MCMC, NUTS, etc.)
 func CheckIfBayesian(results SummaryOutput) bool {
-	isBayesian := funk.Contains([]string{
-		"MCMC Bayesian Analysis",
-		"NUTS Bayesian Analysis",
-	}, results.RunDetails.EstimationMethods[len(results.RunDetails.EstimationMethods)-1])
+	isBayesian := strings.Contains(
+		results.RunDetails.EstimationMethods[len(results.RunDetails.EstimationMethods)-1],
+		"Bayesian Analysis",
+		)
 
 	return isBayesian
 }

--- a/utils/io.go
+++ b/utils/io.go
@@ -20,6 +20,11 @@ func ReadParamsAndOutputFromExt(path string) ([]string, error) {
 	}
 	defer inFile.Close()
 	scanner := bufio.NewScanner(inFile)
+
+	// increase the max buffer size to accommodate very wide tables (lots of params)
+	buf := make([]byte, 0, 16*1024)
+	scanner.Buffer(buf, 256*1024)
+
 	scanner.Split(bufio.ScanLines)
 	var lines []string
 	for scanner.Scan() {
@@ -34,6 +39,16 @@ func ReadParamsAndOutputFromExt(path string) ([]string, error) {
 		default:
 			continue
 		}
+	}
+
+	// explicitly handle line that's too long
+	if scanner.Err() == bufio.ErrTooLong {
+		err_msg := fmt.Sprintf(
+			"ReadParamsAndOutputFromExt() failed on %s with `%s`",
+			path,
+			scanner.Err(),
+		)
+		panic(err_msg)
 	}
 
 	// if file was empty prompt about renamed .ext file

--- a/utils/io.go
+++ b/utils/io.go
@@ -42,13 +42,9 @@ func ReadParamsAndOutputFromExt(path string) ([]string, error) {
 	}
 
 	// explicitly handle line that's too long
-	if scanner.Err() == bufio.ErrTooLong {
-		err_msg := fmt.Sprintf(
-			"ReadParamsAndOutputFromExt() failed on %s with `%s`",
-			path,
-			scanner.Err(),
-		)
-		panic(err_msg)
+	if errors.Is(scanner.Err(), bufio.ErrTooLong) {
+		err = fmt.Errorf("Attempting to parse %s with ReadParamsAndOutputFromExt(): %w", path, scanner.Err())
+		return nil, err
 	}
 
 	// if file was empty prompt about renamed .ext file


### PR DESCRIPTION
We had an example furnished by @timwaterhouse of a model with 102 ETA's that parsed into an empty parameter table. 

The issue was that `ReadParamsAndOutputFromExt()` had an uncaught `bufio.ErrTooLong` because the lines in the `.ext` were longer than the buffer allowed and that was causing it to return an empty array that eventually got passed in to `ParametersData`. 

Increasing the buffer max solved the issue. His (very large) model had an average line size of ~75k. As far as I can see there is not technically a max for how big the lines could be, but I bumped it to 256k which should be plenty big.

