### PR TITLE
fix: reverting to full path in goreleaser.yml ldflags

### DIFF
--- a/cmd/bbi/goreleaser.yml
+++ b/cmd/bbi/goreleaser.yml
@@ -26,7 +26,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w -extldflags "-static" -X 'bbi/cmd.VERSION={{ .Env.VERSION }}'
+      - -s -w -extldflags "-static" -X 'github.com/metrumresearchgroup/bbi/cmd.VERSION={{ .Env.VERSION }}'
     goos:
       - windows
       - darwin


### PR DESCRIPTION
We had to delete and recut the 3.1.0 releases because `goreleaser` wasn't picking up the version to propagate through to the built binaries because this LDFLAGS path was wrong in the `goreleaser.yml`