### PR TITLE
site: include json file with latest non-dev tag

### DIFF
--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -3,8 +3,9 @@ on:
   push:
     branches:
       - scratch/deploy-site
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+  release:
+    types:
+      - released
 
 jobs:
   build:

--- a/docs/site/.gitignore
+++ b/docs/site/.gitignore
@@ -4,4 +4,5 @@
 /local.mk
 /public/
 /resources/
+/static/latest.json
 /static/windows.png

--- a/docs/site/Makefile
+++ b/docs/site/Makefile
@@ -26,7 +26,14 @@ copied_files += content/news.md
 .PHONY: prep
 prep: commands
 prep: $(copied_files)
-	rm -rf public resources
+	rm -rf public resources static/latest.json
+	$(MAKE) static/latest.json
+
+static/latest.json:
+	v=$$(git for-each-ref --sort='-v:refname' --format='%(refname:short)' 'refs/tags/v*' | \
+	     grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$$' | \
+	     head -n1); \
+	  test -n "$$v" && printf '{"version": "%s"}\n' "$$v" >'$@'
 
 command_dir = content/docs/commands
 


### PR DESCRIPTION
Provide bbr with a way to get the latest bbi version without relying on the GitHub API in order to sidestep failures due to rate limiting.

Re: https://github.com/metrumresearchgroup/bbr/issues/736

---

Deployed via push to a scratch branch:
https://github.com/metrumresearchgroup/bbi/actions/runs/15471070684/job/43555331265

```
$ curl -fSsL https://metrumresearchgroup.github.io/bbi/latest.json
{"version": "v3.4.0"}
```
